### PR TITLE
Fix: Online/Offline Status Indicator

### DIFF
--- a/app/(app)/members/[userId]/page.tsx
+++ b/app/(app)/members/[userId]/page.tsx
@@ -15,7 +15,6 @@ import { createClient } from "@/lib/supabase/server";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { Profile } from "@/lib/types";
-import { cn } from "@/lib/utils";
 
 // ─── Member Groups ────────────────────────────────────────────────────────────
 

--- a/app/(app)/members/[userId]/page.tsx
+++ b/app/(app)/members/[userId]/page.tsx
@@ -10,11 +10,10 @@ import {
   UserCircle,
 } from "lucide-react";
 import { QuickCallButton } from "@/components/video/QuickCallButton";
-import { UserAvatar } from "@/components/shared/UserAvatar";
+import { LiveStatusAvatar } from "@/components/shared/LiveStatusAvatar";
 import { createClient } from "@/lib/supabase/server";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { getOnlineStatus } from "@/lib/utils/status";
 import type { Profile } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -137,10 +136,6 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
     viewerDisplayName = (viewerProfile?.display_name as string) ?? "Guest";
   }
 
-  const status = getOnlineStatus(typedProfile.last_seen_at, {
-    isCurrentUser: isOwnProfile,
-  });
-
   const links = [
     {
       url: typedProfile.linkedin_url,
@@ -162,12 +157,12 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   return (
     <div className="mx-auto max-w-2xl space-y-8">
       <div className="flex flex-col gap-6 sm:flex-row sm:items-start">
-        <UserAvatar
+        <LiveStatusAvatar
           avatarUrl={typedProfile.avatar_url}
           displayName={typedProfile.display_name}
           size="xl"
-          showStatus
-          status={status}
+          lastSeenAt={typedProfile.last_seen_at}
+          isCurrentUser={isOwnProfile}
           className="ring-4 ring-background"
         />
         <div className="min-w-0 flex-1">

--- a/components/groups/GroupMemberList.tsx
+++ b/components/groups/GroupMemberList.tsx
@@ -9,8 +9,7 @@ import {
   UserMinus,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { UserAvatar } from "@/components/shared/UserAvatar";
-import { getOnlineStatus } from "@/lib/utils/status";
+import { LiveStatusAvatar } from "@/components/shared/LiveStatusAvatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -104,14 +103,12 @@ export function GroupMemberList({
           return (
             <div key={member.id} className="flex items-center gap-3 py-3">
               <Link href={`/members/${member.id}`} className="shrink-0">
-                <UserAvatar
+                <LiveStatusAvatar
                   avatarUrl={member.avatar_url ?? null}
                   displayName={member.display_name}
                   size="md"
-                  showStatus
-                  status={getOnlineStatus(member.last_seen_at, {
-                    isCurrentUser: member.id === currentUserId,
-                  })}
+                  lastSeenAt={member.last_seen_at}
+                  isCurrentUser={member.id === currentUserId}
                 />
               </Link>
 

--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -9,8 +9,7 @@ import {
   CardContent,
   CardFooter,
 } from "@/components/ui/card";
-import { UserAvatar } from "@/components/shared/UserAvatar";
-import { getOnlineStatus } from "@/lib/utils/status";
+import { LiveStatusAvatar } from "@/components/shared/LiveStatusAvatar";
 import type { Profile } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -27,9 +26,6 @@ interface MemberCardProps {
 }
 
 export default function MemberCard({ profile, currentUserId }: MemberCardProps) {
-  const status = getOnlineStatus(profile.last_seen_at, {
-    isCurrentUser: currentUserId != null && profile.id === currentUserId,
-  });
   const skills = profile.skills ?? [];
   const displaySkills = skills.slice(0, 4);
   const extraCount = skills.length - 4;
@@ -46,12 +42,12 @@ export default function MemberCard({ profile, currentUserId }: MemberCardProps) 
       )}
       <CardContent className="pt-6">
         <div className="flex items-start gap-4">
-          <UserAvatar
+          <LiveStatusAvatar
             avatarUrl={profile.avatar_url}
             displayName={profile.display_name}
             size="lg"
-            showStatus
-            status={status}
+            lastSeenAt={profile.last_seen_at}
+            isCurrentUser={currentUserId != null && profile.id === currentUserId}
           />
           <div className="min-w-0 flex-1">
             <h3 className="truncate font-semibold">{profile.display_name}</h3>

--- a/components/messages/ConversationList.tsx
+++ b/components/messages/ConversationList.tsx
@@ -5,10 +5,9 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
-import { UserAvatar } from "@/components/shared/UserAvatar";
+import { LiveStatusAvatar } from "@/components/shared/LiveStatusAvatar";
 import { getAvatarColor } from "@/lib/utils/avatar";
 import { formatRelativeTime } from "@/lib/utils/time";
-import { getOnlineStatus } from "@/lib/utils/status";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { UsersRound, Archive, Video, BookMarked } from "lucide-react";
@@ -287,7 +286,6 @@ export function ConversationList({
               // DM row
               const otherUser = participants[0];
               if (!otherUser) return null;
-              const onlineStatus = getOnlineStatus(otherUser.last_seen_at);
 
               return (
                 <div
@@ -301,12 +299,11 @@ export function ConversationList({
                     href={`/messages/${conversation.id}`}
                     className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
                   >
-                    <UserAvatar
+                    <LiveStatusAvatar
                       avatarUrl={otherUser.avatar_url ?? null}
                       displayName={otherUser.display_name}
                       size="md"
-                      showStatus
-                      status={onlineStatus}
+                      lastSeenAt={otherUser.last_seen_at}
                     />
 
                     <div className="min-w-0 flex-1">

--- a/components/shared/LiveStatusAvatar.tsx
+++ b/components/shared/LiveStatusAvatar.tsx
@@ -22,6 +22,7 @@ export function LiveStatusAvatar({
   );
 
   useEffect(() => {
+    setStatus(getOnlineStatus(lastSeenAt, { isCurrentUser }));
     const id = setInterval(() => {
       setStatus(getOnlineStatus(lastSeenAt, { isCurrentUser }));
     }, 60_000);

--- a/components/shared/LiveStatusAvatar.tsx
+++ b/components/shared/LiveStatusAvatar.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getOnlineStatus } from "@/lib/utils/status";
+import { UserAvatar } from "./UserAvatar";
+import type { ComponentProps } from "react";
+
+type UserAvatarProps = ComponentProps<typeof UserAvatar>;
+
+interface LiveStatusAvatarProps extends Omit<UserAvatarProps, "status" | "showStatus"> {
+  lastSeenAt: string | null;
+  isCurrentUser?: boolean;
+}
+
+export function LiveStatusAvatar({
+  lastSeenAt,
+  isCurrentUser,
+  ...avatarProps
+}: LiveStatusAvatarProps) {
+  const [status, setStatus] = useState(() =>
+    getOnlineStatus(lastSeenAt, { isCurrentUser })
+  );
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setStatus(getOnlineStatus(lastSeenAt, { isCurrentUser }));
+    }, 60_000);
+    return () => clearInterval(id);
+  }, [lastSeenAt, isCurrentUser]);
+
+  return <UserAvatar {...avatarProps} showStatus status={status} />;
+}


### PR DESCRIPTION
Note: Both the code and the description of this PR contain AI generated portions, this PR was manually tested and verified by a human, and the description was checked for any obvious mistakes. 

**Problem:**
Two bugs were causing the online/offline status dots to be unreliable:                                            
                                                                                                                    
  1. last_seen_at was never written to the DB. The middleware called supabase.rpc('update_last_seen') but didn't
  await it. In Next.js middleware the response is returned immediately, so the unawaited promise was silently
  dropped — meaning last_seen_at stayed null for every user.
  2. Status dots were stale after the initial render. Even with correct data, getOnlineStatus() was called once at
  server render time and never again. A user shown as online at page load would remain green indefinitely, even
  after 30+ minutes of inactivity.

  **Solution:**

  Part 1 — lib/supabase/proxy.ts
  Added await to the update_last_seen RPC call in middleware so the DB write actually completes before the response
  is returned.

  Part 2 — components/shared/LiveStatusAvatar.tsx (new)
  Created a LiveStatusAvatar client component that wraps UserAvatar and re-evaluates getOnlineStatus() every 60
  seconds using Date.now(). Status dots now decay correctly (online → away → offline) while the user stays on the
  page — no polling or network requests needed, since status is pure time arithmetic on last_seen_at.

  Replaced all getOnlineStatus + UserAvatar usages with LiveStatusAvatar in:
  - /members page cards
  - Group member list
  - DM conversation list sidebar
  - Member profile page (/members/[userId])

  Why 60 seconds?

  The thresholds are 5 min (online → away) and 30 min (away → offline). A 60-second re-evaluation interval is more
  than precise enough and matches the middleware's 1-minute last_seen_at update granularity.

  **Not currently in scope:**

  The reverse direction — a previously-offline user coming back online while you're already on the page — would
  require polling or Supabase Realtime. Lower priority; not currently opened as an issue. 
