### PR TITLE
Add My Tools Pulsar integration (matches, brief, persistence, migration)

### DIFF
--- a/app/(app)/app-shell.tsx
+++ b/app/(app)/app-shell.tsx
@@ -19,6 +19,7 @@ import {
   Link2,
   BookMarked,
   ListTodo,
+  WandSparkles,
   GitFork,
   ExternalLink,
 } from "lucide-react";
@@ -47,6 +48,7 @@ const mainNavItems = [
 ];
 
 const myToolsNavItems = [
+  { href: "/my-tools",         label: "Career Match Tools",    icon: WandSparkles },
   { href: "/tracker",          label: "Job Application Tracker", icon: ClipboardList },
   { href: "/learning/tracker", label: "Learning Tracker",        icon: ListTodo },
 ];

--- a/app/(app)/jobs/page.tsx
+++ b/app/(app)/jobs/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { computeJobBoardTier } from "@/lib/jobs/job-board-tier";
 import { JobBoardClient, type JobPosting } from "./JobBoardClient";
 import type { Comment } from "./JobComments";
 
@@ -116,12 +117,12 @@ export default async function JobBoardPage({
   //   1 — has direct community notes (by most recent direct note desc)
   //   2 — is community network       (by job created_at desc)
   //   3 — everything else            (by job created_at desc)
-  const jobTier = (job: JobPosting): number => {
-    if (job.offers_referral) return 0;
-    if ((rawCommentsByJob.get(job.id)?.length ?? 0) > 0) return 1;
-    if (job.is_community_network) return 2;
-    return 3;
-  };
+  const jobTier = (job: JobPosting): number =>
+    computeJobBoardTier({
+      offers_referral: job.offers_referral,
+      is_community_network: job.is_community_network,
+      directCommentCount: rawCommentsByJob.get(job.id)?.length ?? 0,
+    });
 
   filteredJobs.sort((a, b) => {
     const ta = jobTier(a);

--- a/app/(app)/my-tools/MyToolsClient.tsx
+++ b/app/(app)/my-tools/MyToolsClient.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { generateCareerBrief, refreshLiveMatches, saveMatchToTracker } from "./actions";
+import { WhatWeWillMatch } from "@/lib/pulsar/types";
+
+type MatchRun = {
+  request_id: string;
+  candidate_summary: string;
+  created_at: string;
+  matches: WhatWeWillMatch[];
+};
+
+type CareerBrief = {
+  request_id: string;
+  markdown: string;
+  model: string;
+  generated_at: string;
+  created_at: string;
+};
+
+export default function MyToolsClient({
+  latestMatchRun,
+  latestBrief,
+}: {
+  latestMatchRun: MatchRun | null;
+  latestBrief: CareerBrief | null;
+}) {
+  const router = useRouter();
+  const [pendingMatch, startMatch] = useTransition();
+  const [pendingBrief, startBrief] = useTransition();
+  const [savingIds, setSavingIds] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  function onRefreshMatches() {
+    setError(null);
+    startMatch(async () => {
+      const result = await refreshLiveMatches();
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  function onGenerateBrief() {
+    setError(null);
+    startBrief(async () => {
+      const result = await generateCareerBrief();
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  async function onSaveToTracker(match: WhatWeWillMatch) {
+    setError(null);
+    const key = `${match.company}-${match.roleTitle}-${match.applyUrl}`;
+    setSavingIds((prev) => ({ ...prev, [key]: true }));
+    const result = await saveMatchToTracker(match);
+    setSavingIds((prev) => ({ ...prev, [key]: false }));
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">My Tools</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Personalized job matching and career briefing powered by Pulsar.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Live job matches (ATS)</CardTitle>
+          <Button onClick={onRefreshMatches} disabled={pendingMatch}>
+            {pendingMatch ? "Refreshing..." : "Refresh matches"}
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!latestMatchRun ? (
+            <p className="text-sm text-muted-foreground">
+              No match run yet. Click “Refresh matches” to fetch current postings.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                Last run: {new Date(latestMatchRun.created_at).toLocaleString()}
+              </p>
+              <p className="text-sm">{latestMatchRun.candidate_summary}</p>
+              {latestMatchRun.matches.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No matches found in current ATS results.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {latestMatchRun.matches.map((match, idx) => {
+                    const saveKey = `${match.company}-${match.roleTitle}-${match.applyUrl}`;
+                    return (
+                      <div key={`${latestMatchRun.request_id}-${idx}-${saveKey}`} className="rounded-lg border p-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <div>
+                            <p className="font-medium">{match.roleTitle}</p>
+                            <p className="text-sm text-muted-foreground">
+                              {match.company} · {match.location} · {match.label} ({match.score})
+                            </p>
+                          </div>
+                          <div className="flex gap-2">
+                            {match.applyUrl ? (
+                              <a
+                                className="text-sm underline"
+                                href={match.applyUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                Apply link
+                              </a>
+                            ) : null}
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={savingIds[saveKey]}
+                              onClick={() => onSaveToTracker(match)}
+                            >
+                              {savingIds[saveKey] ? "Saving..." : "Add to tracker"}
+                            </Button>
+                          </div>
+                        </div>
+                        <ul className="mt-2 list-disc pl-5 text-sm text-muted-foreground space-y-1">
+                          {match.reasons.map((reason, reasonIdx) => (
+                            <li key={reasonIdx}>{reason}</li>
+                          ))}
+                        </ul>
+                        {match.concern ? (
+                          <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">
+                            Concern: {match.concern}
+                          </p>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Career brief (broader direction)</CardTitle>
+          <Button onClick={onGenerateBrief} disabled={pendingBrief}>
+            {pendingBrief ? "Generating..." : "Generate brief"}
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!latestBrief ? (
+            <p className="text-sm text-muted-foreground">
+              No career brief generated yet.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                Generated: {new Date(latestBrief.created_at).toLocaleString()} · model:{" "}
+                {latestBrief.model}
+              </p>
+              <div className="prose prose-sm dark:prose-invert max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {latestBrief.markdown}
+                </ReactMarkdown>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/app/(app)/my-tools/actions.ts
+++ b/app/(app)/my-tools/actions.ts
@@ -1,0 +1,148 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { fetchPulsarBrief, fetchPulsarMatches } from "@/lib/pulsar/client";
+import {
+  WhatWeWillMatch,
+  WhatWeWillProfileRequest,
+} from "@/lib/pulsar/types";
+
+type ActionResult = { error?: string; ok?: true };
+
+export async function refreshLiveMatches(): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, headline, bio, skills, linkedin_url, location")
+    .eq("id", user.id)
+    .single();
+
+  if (profileError || !profile) {
+    return { error: "Unable to load profile for matching" };
+  }
+
+  const payload = buildProfilePayload(profile);
+
+  try {
+    const response = await fetchPulsarMatches(payload);
+    const { error: insertError } = await supabase.from("member_match_runs").insert({
+      user_id: user.id,
+      request_id: response.requestId,
+      candidate_summary: response.candidateSummary,
+      matches: response.matches,
+    });
+
+    if (insertError) return { error: insertError.message };
+
+    revalidatePath("/my-tools");
+    return { ok: true };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : "Unable to fetch live matches" };
+  }
+}
+
+export async function generateCareerBrief(): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, headline, bio, skills, linkedin_url, location")
+    .eq("id", user.id)
+    .single();
+
+  if (profileError || !profile) {
+    return { error: "Unable to load profile for brief generation" };
+  }
+
+  const payload = buildProfilePayload(profile);
+
+  try {
+    const response = await fetchPulsarBrief({
+      ...payload,
+      tone: "supportive",
+      maxWords: 700,
+      includeIllustrativeLinks: true,
+    });
+
+    const { error: insertError } = await supabase.from("member_career_briefs").insert({
+      user_id: user.id,
+      request_id: response.requestId,
+      markdown: response.markdown,
+      model: response.model,
+      generated_at: response.generatedAt,
+    });
+
+    if (insertError) return { error: insertError.message };
+
+    revalidatePath("/my-tools");
+    return { ok: true };
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error ? error.message : "Unable to generate career brief",
+    };
+  }
+}
+
+export async function saveMatchToTracker(match: WhatWeWillMatch): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const { error } = await supabase.from("job_applications").insert({
+    user_id: user.id,
+    company: match.company,
+    position: match.roleTitle,
+    status: "wishlist",
+    notes: `From Pulsar match (${match.label}, score ${match.score}).`,
+    url: match.applyUrl || null,
+    is_shared: false,
+  });
+
+  if (error) return { error: error.message };
+  revalidatePath("/tracker");
+  revalidatePath("/my-tools");
+  return { ok: true };
+}
+
+function buildProfilePayload(profile: {
+  id: string;
+  headline: string | null;
+  bio: string | null;
+  skills: string[] | null;
+  linkedin_url: string | null;
+  location: string | null;
+}): WhatWeWillProfileRequest {
+  const inferredRoleTitles = profile.headline
+    ? profile.headline
+        .split(/[|,/]/g)
+        .map((v) => v.trim())
+        .filter(Boolean)
+        .slice(0, 3)
+    : [];
+
+  return {
+    personId: profile.id,
+    linkedinUrl: profile.linkedin_url ?? undefined,
+    resumeText: undefined,
+    skills: profile.skills ?? [],
+    experienceSummary: profile.bio ?? undefined,
+    interestedIndustries: [],
+    interestedRoleTitles: inferredRoleTitles,
+    preferredWorkTypes: ["remote", "hybrid"],
+    preferredLocations: profile.location ? [profile.location] : [],
+  };
+}
+

--- a/app/(app)/my-tools/actions.ts
+++ b/app/(app)/my-tools/actions.ts
@@ -4,9 +4,11 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { fetchPulsarBrief, fetchPulsarMatches } from "@/lib/pulsar/client";
 import {
-  WhatWeWillMatch,
-  WhatWeWillProfileRequest,
-} from "@/lib/pulsar/types";
+  buildWhatWeWillBriefRequest,
+  buildWhatWeWillProfilePayload,
+} from "@/lib/pulsar/profile-payload";
+import { jobApplicationInsertFromPulsarMatch } from "@/lib/pulsar/tracker-from-match";
+import type { WhatWeWillMatch } from "@/lib/pulsar/types";
 
 type ActionResult = { error?: string; ok?: true };
 
@@ -27,7 +29,7 @@ export async function refreshLiveMatches(): Promise<ActionResult> {
     return { error: "Unable to load profile for matching" };
   }
 
-  const payload = buildProfilePayload(profile);
+  const payload = buildWhatWeWillProfilePayload(profile);
 
   try {
     const response = await fetchPulsarMatches(payload);
@@ -64,15 +66,10 @@ export async function generateCareerBrief(): Promise<ActionResult> {
     return { error: "Unable to load profile for brief generation" };
   }
 
-  const payload = buildProfilePayload(profile);
+  const briefPayload = buildWhatWeWillBriefRequest(profile);
 
   try {
-    const response = await fetchPulsarBrief({
-      ...payload,
-      tone: "supportive",
-      maxWords: 700,
-      includeIllustrativeLinks: true,
-    });
+    const response = await fetchPulsarBrief(briefPayload);
 
     const { error: insertError } = await supabase.from("member_career_briefs").insert({
       user_id: user.id,
@@ -103,46 +100,12 @@ export async function saveMatchToTracker(match: WhatWeWillMatch): Promise<Action
 
   const { error } = await supabase.from("job_applications").insert({
     user_id: user.id,
-    company: match.company,
-    position: match.roleTitle,
-    status: "wishlist",
-    notes: `From Pulsar match (${match.label}, score ${match.score}).`,
-    url: match.applyUrl || null,
-    is_shared: false,
+    ...jobApplicationInsertFromPulsarMatch(match),
   });
 
   if (error) return { error: error.message };
   revalidatePath("/tracker");
   revalidatePath("/my-tools");
   return { ok: true };
-}
-
-function buildProfilePayload(profile: {
-  id: string;
-  headline: string | null;
-  bio: string | null;
-  skills: string[] | null;
-  linkedin_url: string | null;
-  location: string | null;
-}): WhatWeWillProfileRequest {
-  const inferredRoleTitles = profile.headline
-    ? profile.headline
-        .split(/[|,/]/g)
-        .map((v) => v.trim())
-        .filter(Boolean)
-        .slice(0, 3)
-    : [];
-
-  return {
-    personId: profile.id,
-    linkedinUrl: profile.linkedin_url ?? undefined,
-    resumeText: undefined,
-    skills: profile.skills ?? [],
-    experienceSummary: profile.bio ?? undefined,
-    interestedIndustries: [],
-    interestedRoleTitles: inferredRoleTitles,
-    preferredWorkTypes: ["remote", "hybrid"],
-    preferredLocations: profile.location ? [profile.location] : [],
-  };
 }
 

--- a/app/(app)/my-tools/page.tsx
+++ b/app/(app)/my-tools/page.tsx
@@ -1,0 +1,64 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import MyToolsClient from "./MyToolsClient";
+import { WhatWeWillMatch } from "@/lib/pulsar/types";
+
+type MatchRunRow = {
+  request_id: string;
+  candidate_summary: string;
+  matches: unknown;
+  created_at: string;
+};
+
+type BriefRow = {
+  request_id: string;
+  markdown: string;
+  model: string;
+  generated_at: string;
+  created_at: string;
+};
+
+export default async function MyToolsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const [{ data: latestMatchRun }, { data: latestBrief }] = await Promise.all([
+    supabase
+      .from("member_match_runs")
+      .select("request_id, candidate_summary, matches, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from("member_career_briefs")
+      .select("request_id, markdown, model, generated_at, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  const normalizedMatchRun = latestMatchRun
+    ? {
+        ...(latestMatchRun as MatchRunRow),
+        matches: Array.isArray((latestMatchRun as MatchRunRow).matches)
+          ? ((latestMatchRun as MatchRunRow).matches as WhatWeWillMatch[])
+          : [],
+      }
+    : null;
+
+  return (
+    <MyToolsClient
+      latestMatchRun={normalizedMatchRun}
+      latestBrief={(latestBrief as BriefRow | null) ?? null}
+    />
+  );
+}
+

--- a/lib/jobs/job-board-tier.test.ts
+++ b/lib/jobs/job-board-tier.test.ts
@@ -1,0 +1,43 @@
+import { computeJobBoardTier } from "./job-board-tier";
+
+describe("computeJobBoardTier", () => {
+  it("tier 0 when offers referral", () => {
+    expect(
+      computeJobBoardTier({
+        offers_referral: true,
+        is_community_network: false,
+        directCommentCount: 0,
+      })
+    ).toBe(0);
+  });
+
+  it("tier 1 when has direct comments (even if also community network)", () => {
+    expect(
+      computeJobBoardTier({
+        offers_referral: false,
+        is_community_network: true,
+        directCommentCount: 1,
+      })
+    ).toBe(1);
+  });
+
+  it("tier 2 for community network without comments", () => {
+    expect(
+      computeJobBoardTier({
+        offers_referral: false,
+        is_community_network: true,
+        directCommentCount: 0,
+      })
+    ).toBe(2);
+  });
+
+  it("tier 3 default", () => {
+    expect(
+      computeJobBoardTier({
+        offers_referral: false,
+        is_community_network: false,
+        directCommentCount: 0,
+      })
+    ).toBe(3);
+  });
+});

--- a/lib/jobs/job-board-tier.ts
+++ b/lib/jobs/job-board-tier.ts
@@ -1,0 +1,14 @@
+/**
+ * Job board sort priority (lower = higher in list).
+ * Mirrors logic in `app/(app)/jobs/page.tsx`.
+ */
+export function computeJobBoardTier(input: {
+  offers_referral: boolean;
+  is_community_network: boolean;
+  directCommentCount: number;
+}): number {
+  if (input.offers_referral) return 0;
+  if (input.directCommentCount > 0) return 1;
+  if (input.is_community_network) return 2;
+  return 3;
+}

--- a/lib/pulsar/client.test.ts
+++ b/lib/pulsar/client.test.ts
@@ -1,0 +1,18 @@
+import { normalizePulsarBaseUrl } from "./client";
+
+describe("normalizePulsarBaseUrl", () => {
+  it("strips trailing slashes", () => {
+    expect(normalizePulsarBaseUrl("https://pulsar.example.com/")).toBe(
+      "https://pulsar.example.com"
+    );
+    expect(normalizePulsarBaseUrl("https://pulsar.example.com///")).toBe(
+      "https://pulsar.example.com"
+    );
+  });
+
+  it("does not strip path segments", () => {
+    expect(normalizePulsarBaseUrl("https://pulsar.example.com/api/v1")).toBe(
+      "https://pulsar.example.com/api/v1"
+    );
+  });
+});

--- a/lib/pulsar/client.ts
+++ b/lib/pulsar/client.ts
@@ -5,6 +5,11 @@ import {
   WhatWeWillProfileRequest,
 } from "./types";
 
+/** Strip trailing slashes so `${baseUrl}${path}` is stable. */
+export function normalizePulsarBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
 function getPulsarConfig() {
   const baseUrl = process.env.PULSAR_BASE_URL;
   const apiKey = process.env.WHATWEWILL_API_KEY;
@@ -17,7 +22,7 @@ function getPulsarConfig() {
   }
 
   return {
-    baseUrl: baseUrl.replace(/\/+$/, ""),
+    baseUrl: normalizePulsarBaseUrl(baseUrl),
     apiKey,
   };
 }

--- a/lib/pulsar/client.ts
+++ b/lib/pulsar/client.ts
@@ -1,0 +1,62 @@
+import {
+  WhatWeWillBriefRequest,
+  WhatWeWillBriefResponse,
+  WhatWeWillMatchResponse,
+  WhatWeWillProfileRequest,
+} from "./types";
+
+function getPulsarConfig() {
+  const baseUrl = process.env.PULSAR_BASE_URL;
+  const apiKey = process.env.WHATWEWILL_API_KEY;
+
+  if (!baseUrl) {
+    throw new Error("PULSAR_BASE_URL is not configured");
+  }
+  if (!apiKey) {
+    throw new Error("WHATWEWILL_API_KEY is not configured");
+  }
+
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    apiKey,
+  };
+}
+
+async function postJson<TResponse>(path: string, payload: unknown): Promise<TResponse> {
+  const { baseUrl, apiKey } = getPulsarConfig();
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+    },
+    body: JSON.stringify(payload),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const bodyText = await res.text();
+    throw new Error(`Pulsar request failed (${res.status}): ${bodyText}`);
+  }
+
+  return (await res.json()) as TResponse;
+}
+
+export async function fetchPulsarMatches(
+  payload: WhatWeWillProfileRequest
+): Promise<WhatWeWillMatchResponse> {
+  return postJson<WhatWeWillMatchResponse>(
+    "/api/integrations/whatwewill/match",
+    payload
+  );
+}
+
+export async function fetchPulsarBrief(
+  payload: WhatWeWillBriefRequest
+): Promise<WhatWeWillBriefResponse> {
+  return postJson<WhatWeWillBriefResponse>(
+    "/api/integrations/whatwewill/brief",
+    payload
+  );
+}
+

--- a/lib/pulsar/profile-payload.test.ts
+++ b/lib/pulsar/profile-payload.test.ts
@@ -1,0 +1,73 @@
+import {
+  DEFAULT_CAREER_BRIEF_OPTIONS,
+  buildWhatWeWillBriefRequest,
+  buildWhatWeWillProfilePayload,
+} from "./profile-payload";
+
+describe("buildWhatWeWillProfilePayload", () => {
+  const base = {
+    id: "user-1",
+    headline: null,
+    bio: null,
+    skills: null,
+    linkedin_url: null,
+    location: null,
+  };
+
+  it("maps profile row to Pulsar profile request", () => {
+    const p = buildWhatWeWillProfilePayload({
+      ...base,
+      headline: "Engineer | Manager",
+      bio: "Builder",
+      skills: ["TS", "React"],
+      linkedin_url: "https://linkedin.com/in/x",
+      location: "Remote",
+    });
+    expect(p.personId).toBe("user-1");
+    expect(p.linkedinUrl).toBe("https://linkedin.com/in/x");
+    expect(p.experienceSummary).toBe("Builder");
+    expect(p.skills).toEqual(["TS", "React"]);
+    expect(p.interestedRoleTitles).toEqual(["Engineer", "Manager"]);
+    expect(p.preferredWorkTypes).toEqual(["remote", "hybrid"]);
+    expect(p.preferredLocations).toEqual(["Remote"]);
+    expect(p.interestedIndustries).toEqual([]);
+  });
+
+  it("splits headline on comma and pipe and caps at 3 titles", () => {
+    const p = buildWhatWeWillProfilePayload({
+      ...base,
+      headline: "A, B, C, D",
+    });
+    expect(p.interestedRoleTitles).toEqual(["A", "B", "C"]);
+  });
+
+  it("omits optional fields when empty", () => {
+    const p = buildWhatWeWillProfilePayload(base);
+    expect(p.linkedinUrl).toBeUndefined();
+    expect(p.experienceSummary).toBeUndefined();
+    expect(p.skills).toEqual([]);
+    expect(p.preferredLocations).toEqual([]);
+    expect(p.interestedRoleTitles).toEqual([]);
+  });
+});
+
+describe("buildWhatWeWillBriefRequest", () => {
+  it("extends profile payload with default career brief options", () => {
+    const row = {
+      id: "u1",
+      headline: "Dev",
+      bio: "Bio text here for testing purposes ok",
+      skills: ["a", "b"],
+      linkedin_url: "https://l.com/x",
+      location: "NYC",
+    };
+    const b = buildWhatWeWillBriefRequest(row);
+    expect(b.tone).toBe(DEFAULT_CAREER_BRIEF_OPTIONS.tone);
+    expect(b.maxWords).toBe(DEFAULT_CAREER_BRIEF_OPTIONS.maxWords);
+    expect(b.includeIllustrativeLinks).toBe(
+      DEFAULT_CAREER_BRIEF_OPTIONS.includeIllustrativeLinks
+    );
+    expect(b.personId).toBe("u1");
+    expect(b.interestedRoleTitles).toEqual(["Dev"]);
+  });
+});

--- a/lib/pulsar/profile-payload.ts
+++ b/lib/pulsar/profile-payload.ts
@@ -1,0 +1,54 @@
+import type {
+  WhatWeWillBriefRequest,
+  WhatWeWillProfileRequest,
+} from "./types";
+
+/** Profile columns used for Pulsar match + career brief. */
+export type ProfileRowForPulsar = {
+  id: string;
+  headline: string | null;
+  bio: string | null;
+  skills: string[] | null;
+  linkedin_url: string | null;
+  location: string | null;
+};
+
+export function buildWhatWeWillProfilePayload(
+  profile: ProfileRowForPulsar
+): WhatWeWillProfileRequest {
+  const inferredRoleTitles = profile.headline
+    ? profile.headline
+        .split(/[|,/]/g)
+        .map((v) => v.trim())
+        .filter(Boolean)
+        .slice(0, 3)
+    : [];
+
+  return {
+    personId: profile.id,
+    linkedinUrl: profile.linkedin_url ?? undefined,
+    resumeText: undefined,
+    skills: profile.skills ?? [],
+    experienceSummary: profile.bio ?? undefined,
+    interestedIndustries: [],
+    interestedRoleTitles: inferredRoleTitles,
+    preferredWorkTypes: ["remote", "hybrid"],
+    preferredLocations: profile.location ? [profile.location] : [],
+  };
+}
+
+/** Options passed to Pulsar `/brief` from My Tools. */
+export const DEFAULT_CAREER_BRIEF_OPTIONS = {
+  tone: "supportive" as const,
+  maxWords: 700,
+  includeIllustrativeLinks: true,
+};
+
+export function buildWhatWeWillBriefRequest(
+  profile: ProfileRowForPulsar
+): WhatWeWillBriefRequest {
+  return {
+    ...buildWhatWeWillProfilePayload(profile),
+    ...DEFAULT_CAREER_BRIEF_OPTIONS,
+  };
+}

--- a/lib/pulsar/tracker-from-match.test.ts
+++ b/lib/pulsar/tracker-from-match.test.ts
@@ -1,0 +1,35 @@
+import { jobApplicationInsertFromPulsarMatch } from "./tracker-from-match";
+import type { WhatWeWillMatch } from "./types";
+
+const sampleMatch: WhatWeWillMatch = {
+  score: 82,
+  label: "Strong match",
+  roleTitle: "Staff Engineer",
+  company: "Acme",
+  location: "Remote",
+  source: "greenhouse",
+  reasons: ["Skills align"],
+  applyUrl: "https://jobs.example.com/1",
+};
+
+describe("jobApplicationInsertFromPulsarMatch", () => {
+  it("builds tracker insert fields for a Pulsar match", () => {
+    const row = jobApplicationInsertFromPulsarMatch(sampleMatch);
+    expect(row).toEqual({
+      company: "Acme",
+      position: "Staff Engineer",
+      status: "wishlist",
+      notes: "From Pulsar match (Strong match, score 82).",
+      url: "https://jobs.example.com/1",
+      is_shared: false,
+    });
+  });
+
+  it("uses null url when applyUrl empty", () => {
+    const row = jobApplicationInsertFromPulsarMatch({
+      ...sampleMatch,
+      applyUrl: "",
+    });
+    expect(row.url).toBeNull();
+  });
+});

--- a/lib/pulsar/tracker-from-match.ts
+++ b/lib/pulsar/tracker-from-match.ts
@@ -1,0 +1,15 @@
+import type { WhatWeWillMatch } from "./types";
+
+/**
+ * `job_applications` row fields (except `user_id`) when saving a Pulsar match to the tracker.
+ */
+export function jobApplicationInsertFromPulsarMatch(match: WhatWeWillMatch) {
+  return {
+    company: match.company,
+    position: match.roleTitle,
+    status: "wishlist" as const,
+    notes: `From Pulsar match (${match.label}, score ${match.score}).`,
+    url: match.applyUrl || null,
+    is_shared: false as const,
+  };
+}

--- a/lib/pulsar/types.ts
+++ b/lib/pulsar/types.ts
@@ -1,0 +1,46 @@
+export type PreferredWorkType = "remote" | "hybrid" | "onsite";
+
+export type WhatWeWillProfileRequest = {
+  personId: string;
+  linkedinUrl?: string;
+  resumeText?: string;
+  resumeUrl?: string;
+  skills: string[];
+  experienceSummary?: string;
+  interestedIndustries: string[];
+  interestedRoleTitles: string[];
+  preferredWorkTypes: PreferredWorkType[];
+  preferredLocations: string[];
+};
+
+export type WhatWeWillMatch = {
+  score: number;
+  label: "Strong match" | "Good match" | "Stretch";
+  roleTitle: string;
+  company: string;
+  location: string;
+  source: "greenhouse" | "lever";
+  reasons: string[];
+  concern?: string;
+  applyUrl: string;
+};
+
+export type WhatWeWillMatchResponse = {
+  requestId: string;
+  candidateSummary: string;
+  matches: WhatWeWillMatch[];
+};
+
+export type WhatWeWillBriefRequest = WhatWeWillProfileRequest & {
+  tone?: "supportive" | "direct" | "coach";
+  maxWords?: number;
+  includeIllustrativeLinks?: boolean;
+};
+
+export type WhatWeWillBriefResponse = {
+  requestId: string;
+  markdown: string;
+  model: string;
+  generatedAt: string;
+};
+

--- a/supabase/migrations/057_my_tools_pulsar.sql
+++ b/supabase/migrations/057_my_tools_pulsar.sql
@@ -1,0 +1,48 @@
+-- Persisted outputs for Pulsar-powered My Tools features.
+
+CREATE TABLE IF NOT EXISTS public.member_match_runs (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  request_id        TEXT NOT NULL,
+  candidate_summary TEXT NOT NULL,
+  matches           JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.member_match_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own match runs"
+  ON public.member_match_runs FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Users can create own match runs"
+  ON public.member_match_runs FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE INDEX IF NOT EXISTS idx_member_match_runs_user_created
+  ON public.member_match_runs (user_id, created_at DESC);
+
+
+CREATE TABLE IF NOT EXISTS public.member_career_briefs (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  request_id   TEXT NOT NULL,
+  markdown     TEXT NOT NULL,
+  model        TEXT NOT NULL,
+  generated_at TIMESTAMPTZ NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.member_career_briefs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own career briefs"
+  ON public.member_career_briefs FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Users can create own career briefs"
+  ON public.member_career_briefs FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE INDEX IF NOT EXISTS idx_member_career_briefs_user_created
+  ON public.member_career_briefs (user_id, created_at DESC);
+


### PR DESCRIPTION
### What We Will platform + Pulsar integration plan

- Live matches (ATS) — factual, time-bound, good for “apply now” and links that should work when postings exist. This maps cleanly to the existing Pulsar contract in [docs/integrations-whatwewill.md](https://github.com/GaiaCommons/pulsar/compare/feature/docs/integrations-whatwewill.md) (POST /api/integrations/whatwewill/match).
- Broader career brief (LLM) — strategic, can include inactive or illustrative company/role examples with clear disclaimers. Keeping it separate from ATS results avoids users confusing “open role” with “directional lead.”
- My Tools — natural home for personal outputs (saved brief, last match run, links to tracker).
- Job Board + Job Application Tracker — natural home for curated postings the org trusts and state (applied, interviewed, etc.).

I'll host the LLM brief on Pulsar (second integration endpoint), so the platform stays a thin client + storage for member-facing UI. (For now I'm hosting this on marygfisher.com but will probably create a new domain at some point).

### **Phase 1 — Profile to live matches (platform + existing Pulsar)**

**Goal:** When a member (or staff) triggers “Refresh matches,” the platform calls Pulsar with a payload derived from the member profile.

**Pulsar (already exists): [src/app/api/integrations/whatwewill/match/route.ts]**(https://github.com/GaiaCommons/pulsar/compare/feature/src/app/api/integrations/whatwewill/match/route.ts) — ensure staging/production env has WHATWEWILL_API_KEY and ATS board lists.

**Community platform (github.com/What-We-Will/community-platform):**

- Add server-only config: `PULSAR_BASE_URL`, `WHATWEWILL_API_KEY` (GitHub Actions / hosting secrets — never client-side).
**- Implement a server route or server action that:**
- [ ] Loads the member profile (LinkedIn URL, resume text or parsed text, skills, industries, titles, work type, locations).
- [ ] Maps fields to WhatWeWillProfileRequest (same shape as [docs/integrations-whatwewill.md](https://github.com/GaiaCommons/pulsar/compare/feature/docs/integrations-whatwewill.md)).
- [ ] Calls POST {PULSAR_BASE_URL}/api/integrations/whatwewill/match with x-api-key.
- My Tools (v1 UI): section e.g. “Job matches (live postings)” showing matches[] (title, company, score, apply link, reasons). Optional: store last requestId + timestamp in your DB for audit.

**Guardrails:** rate limit per member, cap payload size, log errors without echoing secrets.

### Phase 2 — Career brief on Pulsar (new endpoint)

**Goal:** Return a markdown (or structured JSON + markdown) document: highlights to emphasize on resume, narrative summary, broad role/company archetypes, and explicitly labeled “illustrative” links where URLs may be stale.

**Pulsar — new route (to implement after plan approval):**

- e.g. POST /api/integrations/whatwewill/brief
- Same auth: x-api-key vs WHATWEWILL_API_KEY (or a dedicated WHATWEWILL_BRIEF_API_KEY if you want to rotate keys independently later).
- Request body: reuse or extend profile fields; add optional tone, maxWords, includeIllustrativeLinks boolean.
- Implementation: OpenAI (or compatible) via server env OPENAI_API_KEY; prompt enforces disclaimers and separates “verified live postings” vs “market direction.”
- Response: { requestId, markdown, model, generatedAt } (and optional structured sections for UI cards).

Platform:

- Server call to new endpoint; persist versioned brief per member (DB row or object storage).
- My Tools: “Career brief” viewer (render markdown), “Regenerate” with cooldown.

### Phase 3 — Job Board resources + tracker

**Goal:** Separate curated opportunities from scraped/ATS matches.

- Job Board: admin or community workflow to publish postings (company, title, URL, source, closes date).
- Tracker: member can add a row from Job Board or from Pulsar match (pre-fill title/company/URL); statuses (saved, applied, interview, offer, closed).
- Optional later: webhook or nightly job to re-validate apply URLs and mark stale rows (does not block v1).

### Security and product notes

- Never expose `WHATWEWILL_API_KEY` or `OPENAI_API_KEY` to the browser; only server-to-server.
- Consent: brief generation is more sensitive (full profile + LLM); log consent timestamp if required by policy.
- Disclaimers: brief UI should state that illustrative links may not be active; ATS section can say postings are third-party and may change.

### Suggested sequencing

1. Phase 1 end-to-end (profile → match → My Tools read-only list).
2. Phase 2 brief endpoint on Pulsar + My Tools viewer + persistence.
3. Phase 3 Job Board + tracker linking.

### Out of scope for this plan (unless you want them next)
- Legal/privacy review copy and data retention policy for stored briefs.
- Expanding ATS beyond Greenhouse/Lever on Pulsar (separate roadmap).
