### PR TITLE
Feature/my tools profile nudges email

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ Optional (for Jitsi JWT / 8x8 JaaS):
 NEXT_PUBLIC_JITSI_APP_ID=your-jaas-app-id
 ```
 
+### Email (Gmail) — DM notifications & My Tools reminders
+
+Direct messages can **email** other thread participants when `GMAIL_USER` and `GMAIL_APP_PASSWORD` (Gmail [app password](https://support.google.com/accounts/answer/185833)) are set. Without them, chat still works but **no inbox email** is sent (see [`app/api/messages/route.ts`](app/api/messages/route.ts)).
+
+For **weekly My Tools reminder** emails (member opt-in on **My Profile**), use the same Gmail vars plus:
+
+```env
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key   # server-only; never expose to the client
+CRON_SECRET=long-random-string                    # Vercel cron sends Authorization: Bearer <CRON_SECRET>
+NEXT_PUBLIC_SITE_URL=https://your-production-domain
+```
+
+Apply migration `058_profile_my_tools_email_prefs.sql`, enable the cron in [`vercel.json`](vercel.json), and set `CRON_SECRET` in the Vercel project. Details: [`docs/mytools-refresh.md`](docs/mytools-refresh.md).
+
+Optional admin notification for new membership applications:
+
+```env
+ADMIN_EMAIL=you@example.com
+```
+
 Get the Supabase values from your project’s **Settings → API** in the Supabase dashboard. If you have not created a blank new Supabase project for this repo please do so now. 
 
 ### 3. Database
@@ -138,6 +158,7 @@ Open [http://localhost:3000](http://localhost:3000). Sign up via the auth flow; 
 | **Dashboard** | Welcome banner, new members, recent chats, community polls, my groups, upcoming events |
 | **Events** | Create/edit/delete events, RSVP (going/maybe/declined), list + calendar view, video link (Jitsi) |
 | **Polls** | Community-wide polls, vote, create poll (dialog + server action) |
+| **My Tools** | Pulsar job matches + career brief (user-triggered); profile completeness nudges; optional weekly email reminder ([`docs/mytools-refresh.md`](docs/mytools-refresh.md)) |
 
 ---
 

--- a/app/(app)/app-shell.tsx
+++ b/app/(app)/app-shell.tsx
@@ -19,6 +19,7 @@ import {
   Link2,
   BookMarked,
   ListTodo,
+  WandSparkles,
   GitFork,
   ExternalLink,
 } from "lucide-react";
@@ -47,6 +48,7 @@ const mainNavItems = [
 ];
 
 const myToolsNavItems = [
+  { href: "/my-tools",         label: "Career Match Tools",    icon: WandSparkles },
   { href: "/tracker",          label: "Job Application Tracker", icon: ClipboardList },
   { href: "/learning/tracker", label: "Learning Tracker",        icon: ListTodo },
 ];

--- a/app/(app)/my-tools/MyToolsClient.tsx
+++ b/app/(app)/my-tools/MyToolsClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import ReactMarkdown from "react-markdown";
@@ -8,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { generateCareerBrief, refreshLiveMatches, saveMatchToTracker } from "./actions";
 import { WhatWeWillMatch } from "@/lib/pulsar/types";
+import type { ProfileCompleteness } from "@/lib/profile-completeness";
 
 type MatchRun = {
   request_id: string;
@@ -24,12 +26,18 @@ type CareerBrief = {
   created_at: string;
 };
 
+const STALE_MATCH_DAYS = 7;
+
 export default function MyToolsClient({
   latestMatchRun,
   latestBrief,
+  profileCompleteness,
+  matchRunAgeDays,
 }: {
   latestMatchRun: MatchRun | null;
   latestBrief: CareerBrief | null;
+  profileCompleteness: ProfileCompleteness;
+  matchRunAgeDays: number | null;
 }) {
   const router = useRouter();
   const [pendingMatch, startMatch] = useTransition();
@@ -89,6 +97,28 @@ export default function MyToolsClient({
         </div>
       )}
 
+      {!profileCompleteness.isStrong && (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
+          <p className="font-medium text-amber-950 dark:text-amber-100">
+            Stronger profile → better matches ({profileCompleteness.score}/100)
+          </p>
+          <p className="mt-1 text-muted-foreground">
+            Add: {profileCompleteness.missing.join(", ")}.
+          </p>
+          <Button asChild variant="secondary" size="sm" className="mt-3">
+            <Link href="/profile">Update my profile</Link>
+          </Button>
+        </div>
+      )}
+
+      {matchRunAgeDays !== null && matchRunAgeDays >= STALE_MATCH_DAYS && (
+        <div className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+          Your last match run was {matchRunAgeDays} day
+          {matchRunAgeDays === 1 ? "" : "s"} ago. Postings change often—use{" "}
+          <strong>Refresh matches</strong> when you want an up-to-date list.
+        </div>
+      )}
+
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Live job matches (ATS)</CardTitle>
@@ -100,6 +130,16 @@ export default function MyToolsClient({
           {!latestMatchRun ? (
             <p className="text-sm text-muted-foreground">
               No match run yet. Click “Refresh matches” to fetch current postings.
+              {!profileCompleteness.isStrong ? (
+                <>
+                  {" "}
+                  Expect more relevant results after you{" "}
+                  <Link href="/profile" className="underline text-foreground">
+                    enrich your profile
+                  </Link>
+                  .
+                </>
+              ) : null}
             </p>
           ) : (
             <>

--- a/app/(app)/my-tools/MyToolsClient.tsx
+++ b/app/(app)/my-tools/MyToolsClient.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { generateCareerBrief, refreshLiveMatches, saveMatchToTracker } from "./actions";
+import { WhatWeWillMatch } from "@/lib/pulsar/types";
+
+type MatchRun = {
+  request_id: string;
+  candidate_summary: string;
+  created_at: string;
+  matches: WhatWeWillMatch[];
+};
+
+type CareerBrief = {
+  request_id: string;
+  markdown: string;
+  model: string;
+  generated_at: string;
+  created_at: string;
+};
+
+export default function MyToolsClient({
+  latestMatchRun,
+  latestBrief,
+}: {
+  latestMatchRun: MatchRun | null;
+  latestBrief: CareerBrief | null;
+}) {
+  const router = useRouter();
+  const [pendingMatch, startMatch] = useTransition();
+  const [pendingBrief, startBrief] = useTransition();
+  const [savingIds, setSavingIds] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  function onRefreshMatches() {
+    setError(null);
+    startMatch(async () => {
+      const result = await refreshLiveMatches();
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  function onGenerateBrief() {
+    setError(null);
+    startBrief(async () => {
+      const result = await generateCareerBrief();
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  async function onSaveToTracker(match: WhatWeWillMatch) {
+    setError(null);
+    const key = `${match.company}-${match.roleTitle}-${match.applyUrl}`;
+    setSavingIds((prev) => ({ ...prev, [key]: true }));
+    const result = await saveMatchToTracker(match);
+    setSavingIds((prev) => ({ ...prev, [key]: false }));
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">My Tools</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Personalized job matching and career briefing powered by Pulsar.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Live job matches (ATS)</CardTitle>
+          <Button onClick={onRefreshMatches} disabled={pendingMatch}>
+            {pendingMatch ? "Refreshing..." : "Refresh matches"}
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!latestMatchRun ? (
+            <p className="text-sm text-muted-foreground">
+              No match run yet. Click “Refresh matches” to fetch current postings.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                Last run: {new Date(latestMatchRun.created_at).toLocaleString()}
+              </p>
+              <p className="text-sm">{latestMatchRun.candidate_summary}</p>
+              {latestMatchRun.matches.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No matches found in current ATS results.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {latestMatchRun.matches.map((match, idx) => {
+                    const saveKey = `${match.company}-${match.roleTitle}-${match.applyUrl}`;
+                    return (
+                      <div key={`${latestMatchRun.request_id}-${idx}-${saveKey}`} className="rounded-lg border p-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <div>
+                            <p className="font-medium">{match.roleTitle}</p>
+                            <p className="text-sm text-muted-foreground">
+                              {match.company} · {match.location} · {match.label} ({match.score})
+                            </p>
+                          </div>
+                          <div className="flex gap-2">
+                            {match.applyUrl ? (
+                              <a
+                                className="text-sm underline"
+                                href={match.applyUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                Apply link
+                              </a>
+                            ) : null}
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={savingIds[saveKey]}
+                              onClick={() => onSaveToTracker(match)}
+                            >
+                              {savingIds[saveKey] ? "Saving..." : "Add to tracker"}
+                            </Button>
+                          </div>
+                        </div>
+                        <ul className="mt-2 list-disc pl-5 text-sm text-muted-foreground space-y-1">
+                          {match.reasons.map((reason, reasonIdx) => (
+                            <li key={reasonIdx}>{reason}</li>
+                          ))}
+                        </ul>
+                        {match.concern ? (
+                          <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">
+                            Concern: {match.concern}
+                          </p>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Career brief (broader direction)</CardTitle>
+          <Button onClick={onGenerateBrief} disabled={pendingBrief}>
+            {pendingBrief ? "Generating..." : "Generate brief"}
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!latestBrief ? (
+            <p className="text-sm text-muted-foreground">
+              No career brief generated yet.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                Generated: {new Date(latestBrief.created_at).toLocaleString()} · model:{" "}
+                {latestBrief.model}
+              </p>
+              <div className="prose prose-sm dark:prose-invert max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {latestBrief.markdown}
+                </ReactMarkdown>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/app/(app)/my-tools/actions.ts
+++ b/app/(app)/my-tools/actions.ts
@@ -1,5 +1,12 @@
 "use server";
 
+/**
+ * My Tools ↔ Pulsar: all match and career-brief calls are **user-triggered** only
+ * (buttons in the UI). There is no scheduled batch refresh in this app—doing so
+ * would scale cost with membership (ATS + LLM). For periodic nudges without API
+ * cost, see the weekly email cron (`/api/cron/my-tools-reminders`) and
+ * `docs/mytools-refresh.md`.
+ */
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { fetchPulsarBrief, fetchPulsarMatches } from "@/lib/pulsar/client";

--- a/app/(app)/my-tools/actions.ts
+++ b/app/(app)/my-tools/actions.ts
@@ -1,0 +1,148 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { fetchPulsarBrief, fetchPulsarMatches } from "@/lib/pulsar/client";
+import {
+  WhatWeWillMatch,
+  WhatWeWillProfileRequest,
+} from "@/lib/pulsar/types";
+
+type ActionResult = { error?: string; ok?: true };
+
+export async function refreshLiveMatches(): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, headline, bio, skills, linkedin_url, location")
+    .eq("id", user.id)
+    .single();
+
+  if (profileError || !profile) {
+    return { error: "Unable to load profile for matching" };
+  }
+
+  const payload = buildProfilePayload(profile);
+
+  try {
+    const response = await fetchPulsarMatches(payload);
+    const { error: insertError } = await supabase.from("member_match_runs").insert({
+      user_id: user.id,
+      request_id: response.requestId,
+      candidate_summary: response.candidateSummary,
+      matches: response.matches,
+    });
+
+    if (insertError) return { error: insertError.message };
+
+    revalidatePath("/my-tools");
+    return { ok: true };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : "Unable to fetch live matches" };
+  }
+}
+
+export async function generateCareerBrief(): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, headline, bio, skills, linkedin_url, location")
+    .eq("id", user.id)
+    .single();
+
+  if (profileError || !profile) {
+    return { error: "Unable to load profile for brief generation" };
+  }
+
+  const payload = buildProfilePayload(profile);
+
+  try {
+    const response = await fetchPulsarBrief({
+      ...payload,
+      tone: "supportive",
+      maxWords: 700,
+      includeIllustrativeLinks: true,
+    });
+
+    const { error: insertError } = await supabase.from("member_career_briefs").insert({
+      user_id: user.id,
+      request_id: response.requestId,
+      markdown: response.markdown,
+      model: response.model,
+      generated_at: response.generatedAt,
+    });
+
+    if (insertError) return { error: insertError.message };
+
+    revalidatePath("/my-tools");
+    return { ok: true };
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error ? error.message : "Unable to generate career brief",
+    };
+  }
+}
+
+export async function saveMatchToTracker(match: WhatWeWillMatch): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
+
+  const { error } = await supabase.from("job_applications").insert({
+    user_id: user.id,
+    company: match.company,
+    position: match.roleTitle,
+    status: "wishlist",
+    notes: `From Pulsar match (${match.label}, score ${match.score}).`,
+    url: match.applyUrl || null,
+    is_shared: false,
+  });
+
+  if (error) return { error: error.message };
+  revalidatePath("/tracker");
+  revalidatePath("/my-tools");
+  return { ok: true };
+}
+
+function buildProfilePayload(profile: {
+  id: string;
+  headline: string | null;
+  bio: string | null;
+  skills: string[] | null;
+  linkedin_url: string | null;
+  location: string | null;
+}): WhatWeWillProfileRequest {
+  const inferredRoleTitles = profile.headline
+    ? profile.headline
+        .split(/[|,/]/g)
+        .map((v) => v.trim())
+        .filter(Boolean)
+        .slice(0, 3)
+    : [];
+
+  return {
+    personId: profile.id,
+    linkedinUrl: profile.linkedin_url ?? undefined,
+    resumeText: undefined,
+    skills: profile.skills ?? [],
+    experienceSummary: profile.bio ?? undefined,
+    interestedIndustries: [],
+    interestedRoleTitles: inferredRoleTitles,
+    preferredWorkTypes: ["remote", "hybrid"],
+    preferredLocations: profile.location ? [profile.location] : [],
+  };
+}
+

--- a/app/(app)/my-tools/page.tsx
+++ b/app/(app)/my-tools/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import MyToolsClient from "./MyToolsClient";
 import { WhatWeWillMatch } from "@/lib/pulsar/types";
+import { getProfileCompleteness } from "@/lib/profile-completeness";
 
 type MatchRunRow = {
   request_id: string;
@@ -28,7 +29,11 @@ export default async function MyToolsPage() {
     redirect("/login");
   }
 
-  const [{ data: latestMatchRun }, { data: latestBrief }] = await Promise.all([
+  const [
+    { data: latestMatchRun },
+    { data: latestBrief },
+    { data: profileRow },
+  ] = await Promise.all([
     supabase
       .from("member_match_runs")
       .select("request_id, candidate_summary, matches, created_at")
@@ -43,7 +48,26 @@ export default async function MyToolsPage() {
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle(),
+    supabase
+      .from("profiles")
+      .select("headline, bio, skills, linkedin_url, location")
+      .eq("id", user.id)
+      .maybeSingle(),
   ]);
+
+  const profileCompleteness = getProfileCompleteness({
+    headline: profileRow?.headline ?? null,
+    bio: profileRow?.bio ?? null,
+    skills: profileRow?.skills ?? null,
+    linkedin_url: profileRow?.linkedin_url ?? null,
+    location: profileRow?.location ?? null,
+  });
+
+  let matchRunAgeDays: number | null = null;
+  if (latestMatchRun?.created_at) {
+    const ms = Date.now() - new Date(latestMatchRun.created_at).getTime();
+    matchRunAgeDays = Math.floor(ms / (24 * 60 * 60 * 1000));
+  }
 
   const normalizedMatchRun = latestMatchRun
     ? {
@@ -58,6 +82,8 @@ export default async function MyToolsPage() {
     <MyToolsClient
       latestMatchRun={normalizedMatchRun}
       latestBrief={(latestBrief as BriefRow | null) ?? null}
+      profileCompleteness={profileCompleteness}
+      matchRunAgeDays={matchRunAgeDays}
     />
   );
 }

--- a/app/(app)/my-tools/page.tsx
+++ b/app/(app)/my-tools/page.tsx
@@ -1,0 +1,64 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import MyToolsClient from "./MyToolsClient";
+import { WhatWeWillMatch } from "@/lib/pulsar/types";
+
+type MatchRunRow = {
+  request_id: string;
+  candidate_summary: string;
+  matches: unknown;
+  created_at: string;
+};
+
+type BriefRow = {
+  request_id: string;
+  markdown: string;
+  model: string;
+  generated_at: string;
+  created_at: string;
+};
+
+export default async function MyToolsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const [{ data: latestMatchRun }, { data: latestBrief }] = await Promise.all([
+    supabase
+      .from("member_match_runs")
+      .select("request_id, candidate_summary, matches, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from("member_career_briefs")
+      .select("request_id, markdown, model, generated_at, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  const normalizedMatchRun = latestMatchRun
+    ? {
+        ...(latestMatchRun as MatchRunRow),
+        matches: Array.isArray((latestMatchRun as MatchRunRow).matches)
+          ? ((latestMatchRun as MatchRunRow).matches as WhatWeWillMatch[])
+          : [],
+      }
+    : null;
+
+  return (
+    <MyToolsClient
+      latestMatchRun={normalizedMatchRun}
+      latestBrief={(latestBrief as BriefRow | null) ?? null}
+    />
+  );
+}
+

--- a/app/(app)/profile/actions.ts
+++ b/app/(app)/profile/actions.ts
@@ -16,6 +16,8 @@ export async function updateProfile(
     linkedin_url?: string | null;
     github_url?: string | null;
     portfolio_url?: string | null;
+    /** Opt-in weekly email: My Tools / profile reminder (no automatic Pulsar refresh). */
+    email_my_tools_reminders: boolean;
   }
 ): Promise<ProfileUpdateResult> {
   const supabase = await createClient();
@@ -42,6 +44,7 @@ export async function updateProfile(
       github_url: data.github_url || null,
       portfolio_url: data.portfolio_url || null,
       is_onboarded: true,
+      email_my_tools_reminders: data.email_my_tools_reminders,
     },
     { onConflict: "id" }
   );

--- a/app/(app)/profile/profile-form.tsx
+++ b/app/(app)/profile/profile-form.tsx
@@ -42,6 +42,9 @@ export default function ProfileForm({ profile }: ProfileFormProps) {
   const [portfolioUrl, setPortfolioUrl] = useState(
     profile.portfolio_url ?? ""
   );
+  const [emailMyToolsReminders, setEmailMyToolsReminders] = useState(
+    profile.email_my_tools_reminders ?? false
+  );
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -56,6 +59,7 @@ export default function ProfileForm({ profile }: ProfileFormProps) {
     setLinkedinUrl(profile.linkedin_url ?? "");
     setGithubUrl(profile.github_url ?? "");
     setPortfolioUrl(profile.portfolio_url ?? "");
+    setEmailMyToolsReminders(profile.email_my_tools_reminders ?? false);
   }, [profile]);
 
   const router = useRouter();
@@ -82,6 +86,7 @@ export default function ProfileForm({ profile }: ProfileFormProps) {
         linkedin_url: linkedinUrl || null,
         github_url: githubUrl || null,
         portfolio_url: portfolioUrl || null,
+        email_my_tools_reminders: emailMyToolsReminders,
       });
 
       if (result.error) {
@@ -199,6 +204,28 @@ export default function ProfileForm({ profile }: ProfileFormProps) {
             >
               Open to Mock Interviews
             </Label>
+          </div>
+          <div className="rounded-lg border border-border bg-muted/30 p-4 space-y-2">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="email_my_tools_reminders"
+                checked={emailMyToolsReminders}
+                onCheckedChange={(checked) =>
+                  setEmailMyToolsReminders(checked === true)
+                }
+              />
+              <Label
+                htmlFor="email_my_tools_reminders"
+                className="cursor-pointer text-sm font-normal leading-snug"
+              >
+                Email me a weekly reminder about My Tools (refresh matches / update
+                profile)
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground pl-6">
+              We don&apos;t run job matching automatically—you&apos;ll get at most one
+              email per week with links to the app. Turn off anytime here.
+            </p>
           </div>
           <div className="space-y-2">
             <Label htmlFor="linkedin_url">LinkedIn URL</Label>

--- a/app/api/cron/my-tools-reminders/route.ts
+++ b/app/api/cron/my-tools-reminders/route.ts
@@ -2,22 +2,13 @@ import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { sendMyToolsReminderEmail } from "@/lib/email";
 import { getProfileCompleteness } from "@/lib/profile-completeness";
+import { missingFieldToReminderTip } from "@/lib/my-tools-reminder-tips";
+import {
+  MY_TOOLS_REMINDER_COOLDOWN_DAYS,
+  canSendReminderEmail,
+} from "@/lib/my-tools-reminder-schedule";
 
 export const dynamic = "force-dynamic";
-
-function tipFromMissingField(m: string): string {
-  if (m.startsWith("At least")) return `Add ${m.toLowerCase()}.`;
-  if (m === "Bio") return "Add a short career summary to your bio.";
-  if (m === "A longer bio (40+ characters)")
-    return "Expand your bio to at least 40 characters.";
-  if (m === "LinkedIn URL") return "Add your LinkedIn URL.";
-  if (m === "Headline") return "Add a professional headline.";
-  if (m === "Location") return "Add your location.";
-  return `Complete: ${m}.`;
-}
-
-/** Minimum days between reminder emails per member. */
-const COOLDOWN_DAYS = 7;
 /** Cap per invocation to stay within serverless time limits. */
 const MAX_SEND_PER_RUN = 40;
 
@@ -47,9 +38,7 @@ export async function GET(request: Request) {
   const myToolsUrl = `${siteUrl.replace(/\/$/, "")}/my-tools`;
   const profileUrl = `${siteUrl.replace(/\/$/, "")}/profile`;
 
-  const cutoff = new Date(
-    Date.now() - COOLDOWN_DAYS * 24 * 60 * 60 * 1000
-  ).toISOString();
+  const now = new Date();
 
   const { data: candidates, error: qErr } = await service
     .from("profiles")
@@ -66,10 +55,12 @@ export async function GET(request: Request) {
   }
 
   const eligible = (candidates ?? [])
-    .filter(
-      (p) =>
-        !p.last_my_tools_reminder_sent_at ||
-        p.last_my_tools_reminder_sent_at < cutoff
+    .filter((p) =>
+      canSendReminderEmail(
+        p.last_my_tools_reminder_sent_at ?? null,
+        now,
+        MY_TOOLS_REMINDER_COOLDOWN_DAYS
+      )
     )
     .slice(0, MAX_SEND_PER_RUN);
 
@@ -96,7 +87,7 @@ export async function GET(request: Request) {
 
     const tips =
       completeness.score < 80
-        ? completeness.missing.map((m) => tipFromMissingField(m))
+        ? completeness.missing.map((m) => missingFieldToReminderTip(m))
         : [];
 
     const result = await sendMyToolsReminderEmail({

--- a/app/api/cron/my-tools-reminders/route.ts
+++ b/app/api/cron/my-tools-reminders/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { sendMyToolsReminderEmail } from "@/lib/email";
+import { getProfileCompleteness } from "@/lib/profile-completeness";
+
+export const dynamic = "force-dynamic";
+
+function tipFromMissingField(m: string): string {
+  if (m.startsWith("At least")) return `Add ${m.toLowerCase()}.`;
+  if (m === "Bio") return "Add a short career summary to your bio.";
+  if (m === "A longer bio (40+ characters)")
+    return "Expand your bio to at least 40 characters.";
+  if (m === "LinkedIn URL") return "Add your LinkedIn URL.";
+  if (m === "Headline") return "Add a professional headline.";
+  if (m === "Location") return "Add your location.";
+  return `Complete: ${m}.`;
+}
+
+/** Minimum days between reminder emails per member. */
+const COOLDOWN_DAYS = 7;
+/** Cap per invocation to stay within serverless time limits. */
+const MAX_SEND_PER_RUN = 40;
+
+/**
+ * Weekly cron (see `vercel.json`). Sends opt-in reminder emails only.
+ * Secured with `Authorization: Bearer ${CRON_SECRET}` (set CRON_SECRET in Vercel).
+ */
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  const auth = request.headers.get("authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let service;
+  try {
+    service = createServiceClient();
+  } catch {
+    return NextResponse.json(
+      { error: "Server misconfigured (Supabase service role)" },
+      { status: 503 }
+    );
+  }
+
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://members.wwwrise.org";
+  const myToolsUrl = `${siteUrl.replace(/\/$/, "")}/my-tools`;
+  const profileUrl = `${siteUrl.replace(/\/$/, "")}/profile`;
+
+  const cutoff = new Date(
+    Date.now() - COOLDOWN_DAYS * 24 * 60 * 60 * 1000
+  ).toISOString();
+
+  const { data: candidates, error: qErr } = await service
+    .from("profiles")
+    .select(
+      "id, display_name, headline, bio, skills, linkedin_url, location, last_my_tools_reminder_sent_at, approval_status, is_onboarded, email_my_tools_reminders"
+    )
+    .eq("email_my_tools_reminders", true)
+    .eq("is_onboarded", true)
+    .eq("approval_status", "approved");
+
+  if (qErr) {
+    console.error("[cron/my-tools-reminders] query error:", qErr.message);
+    return NextResponse.json({ error: qErr.message }, { status: 500 });
+  }
+
+  const eligible = (candidates ?? [])
+    .filter(
+      (p) =>
+        !p.last_my_tools_reminder_sent_at ||
+        p.last_my_tools_reminder_sent_at < cutoff
+    )
+    .slice(0, MAX_SEND_PER_RUN);
+
+  let sent = 0;
+  let failed = 0;
+  const errors: string[] = [];
+
+  for (const row of eligible) {
+    const { data: authUser, error: authErr } =
+      await service.auth.admin.getUserById(row.id);
+    if (authErr || !authUser.user?.email) {
+      failed += 1;
+      errors.push(`no email for ${row.id}`);
+      continue;
+    }
+
+    const completeness = getProfileCompleteness({
+      headline: row.headline,
+      bio: row.bio,
+      skills: row.skills,
+      linkedin_url: row.linkedin_url,
+      location: row.location,
+    });
+
+    const tips =
+      completeness.score < 80
+        ? completeness.missing.map((m) => tipFromMissingField(m))
+        : [];
+
+    const result = await sendMyToolsReminderEmail({
+      to: authUser.user.email,
+      displayName: row.display_name,
+      myToolsUrl,
+      profileUrl,
+      tips,
+    });
+
+    if (!result.ok) {
+      failed += 1;
+      errors.push(`${authUser.user.email}: ${result.reason}`);
+      continue;
+    }
+
+    const { error: upErr } = await service
+      .from("profiles")
+      .update({ last_my_tools_reminder_sent_at: new Date().toISOString() })
+      .eq("id", row.id);
+
+    if (upErr) {
+      failed += 1;
+      errors.push(`update ${row.id}: ${upErr.message}`);
+      continue;
+    }
+
+    sent += 1;
+  }
+
+  return NextResponse.json({
+    ok: true,
+    eligible: eligible.length,
+    sent,
+    failed,
+    errors: errors.slice(0, 10),
+  });
+}

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
-import nodemailer from "nodemailer";
+import { createGmailTransport, getMailFromHeader } from "@/lib/email";
 
 /** Returns true if the given ISO timestamp is from before today (UTC). */
 function notSeenToday(lastSeenAt: string | null): boolean {
@@ -70,9 +70,9 @@ async function sendNotifications({
   messageType: string;
   content: string;
 }) {
-  const gmailUser = process.env.GMAIL_USER;
-  const gmailPass = process.env.GMAIL_APP_PASSWORD;
-  if (!gmailUser || !gmailPass) {
+  const transporter = createGmailTransport();
+  const fromHeader = getMailFromHeader();
+  if (!transporter || !fromHeader) {
     console.warn("[messages/notify] GMAIL_USER or GMAIL_APP_PASSWORD not set — skipping email");
     return;
   }
@@ -119,11 +119,6 @@ async function sendNotifications({
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://members.wwwrise.org";
 
-  const transporter = nodemailer.createTransport({
-    service: "gmail",
-    auth: { user: gmailUser, pass: gmailPass },
-  });
-
   for (const participant of participants) {
     if (participant.muted) continue;
 
@@ -154,7 +149,7 @@ async function sendNotifications({
 
     try {
       await transporter.sendMail({
-        from: `What We Will <${gmailUser}>`,
+        from: fromHeader,
         to: recipientAuth.email,
         subject: `New message from ${senderName}`,
         html: `

--- a/components/messages/ConversationView.tsx
+++ b/components/messages/ConversationView.tsx
@@ -68,6 +68,8 @@ function buildSenderProfile(user: CurrentUser): Profile {
     approval_status: "approved",
     role: "member",
     last_seen_at: null,
+    email_my_tools_reminders: false,
+    last_my_tools_reminder_sent_at: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   };

--- a/docs/mytools-refresh.md
+++ b/docs/mytools-refresh.md
@@ -39,3 +39,7 @@ Running matches or briefs on a schedule for every member would multiply **ATS + 
 
 - **Profile completeness** (headline, bio, skills, location, LinkedIn) is shown on My Tools when the score is below 80/100, with a link to `/profile`.
 - If the last match run is **7+ days** old, a non-blocking “stale matches” note encourages a manual refresh.
+
+## Tests
+
+Jest covers the pure logic: `lib/profile-completeness.test.ts`, `lib/my-tools-reminder-tips.test.ts`, `lib/my-tools-reminder-schedule.test.ts`, and `lib/email.test.ts` (mail-not-configured path). Run `npm test`.

--- a/docs/mytools-refresh.md
+++ b/docs/mytools-refresh.md
@@ -1,0 +1,41 @@
+# My Tools refresh model (Pulsar)
+
+## User-triggered (default)
+
+- **Live matches** and **career brief** are only requested from Pulsar when a signed-in member clicks **Refresh matches** or **Generate brief** on [My Tools](/app/(app)/my-tools/).
+- Each run is stored in Supabase (`member_match_runs`, `member_career_briefs`) for display and history.
+- **Cost scales with actual usage**, not with total membership.
+
+## No automatic batch refresh (by design)
+
+Running matches or briefs on a schedule for every member would multiply **ATS + LLM** cost by **N users × frequency**. If you add batch jobs later:
+
+- Use a **hard cap** per day (e.g. max users or max API calls).
+- Prefer **cohorts** (e.g. active in the last 7 days).
+- Store **last auto-run** timestamps and respect per-user cooldowns.
+
+## Weekly email reminder (opt-in)
+
+- Members can enable **“Email me a weekly reminder…”** on **My Profile**.
+- The Vercel cron job (`vercel.json` → `/api/cron/my-tools-reminders`) runs **weekly** and sends **at most one email per member per 7 days** (tracked on `profiles.last_my_tools_reminder_sent_at`).
+- The email **does not call Pulsar**; it only links members back to the app to refresh manually.
+
+### Required environment variables
+
+- `CRON_SECRET` — must match the secret Vercel sends as `Authorization: Bearer …` on cron invocations.
+- `GMAIL_USER`, `GMAIL_APP_PASSWORD` — same Gmail app password used for DM notifications.
+- `NEXT_PUBLIC_SITE_URL` — production site base URL for links in the email.
+- `SUPABASE_SERVICE_ROLE_KEY` — service role client updates `last_my_tools_reminder_sent_at` and reads opted-in profiles.
+
+### After deploy
+
+1. Apply migration `058_profile_my_tools_email_prefs.sql` (adds `email_my_tools_reminders`, `last_my_tools_reminder_sent_at`).
+2. Set `CRON_SECRET` in Vercel (generate a long random string).
+3. Confirm the cron appears under the project’s **Cron Jobs** tab.
+
+**Plan note:** Scheduled jobs may require a Vercel plan that includes [Cron Jobs](https://vercel.com/docs/cron-jobs); if cron is unavailable, members can still use in-app nudges and manual refresh.
+
+## In-app nudges
+
+- **Profile completeness** (headline, bio, skills, location, LinkedIn) is shown on My Tools when the score is below 80/100, with a link to `/profile`.
+- If the last match run is **7+ days** old, a non-blocking “stale matches” note encourages a manual refresh.

--- a/lib/email.test.ts
+++ b/lib/email.test.ts
@@ -1,0 +1,22 @@
+import { sendMyToolsReminderEmail } from "./email";
+
+describe("sendMyToolsReminderEmail", () => {
+  const saved = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("returns mail_not_configured when Gmail is not set up", async () => {
+    delete process.env.GMAIL_USER;
+    delete process.env.GMAIL_APP_PASSWORD;
+    const result = await sendMyToolsReminderEmail({
+      to: "u@example.com",
+      displayName: "Test User",
+      myToolsUrl: "https://example.com/my-tools",
+      profileUrl: "https://example.com/profile",
+      tips: ["Add your headline."],
+    });
+    expect(result).toEqual({ ok: false, reason: "mail_not_configured" });
+  });
+});

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,88 @@
+import nodemailer from "nodemailer";
+import type { Transporter } from "nodemailer";
+
+/**
+ * Shared Gmail transport for member-facing email (DM notifications, My Tools reminders).
+ * Requires GMAIL_USER + GMAIL_APP_PASSWORD in the environment.
+ */
+export function createGmailTransport(): Transporter | null {
+  const user = process.env.GMAIL_USER;
+  const pass = process.env.GMAIL_APP_PASSWORD;
+  if (!user || !pass) return null;
+  return nodemailer.createTransport({
+    service: "gmail",
+    auth: { user, pass },
+  });
+}
+
+export function getMailFromHeader(): string | null {
+  const user = process.env.GMAIL_USER;
+  if (!user) return null;
+  return `What We Will <${user}>`;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Weekly-style reminder: links to My Tools (user must click Refresh for Pulsar; no API cost here).
+ */
+export async function sendMyToolsReminderEmail(opts: {
+  to: string;
+  displayName: string;
+  myToolsUrl: string;
+  profileUrl: string;
+  tips: string[];
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const transport = createGmailTransport();
+  const from = getMailFromHeader();
+  if (!transport || !from) {
+    return { ok: false, reason: "mail_not_configured" };
+  }
+
+  const tipsHtml =
+    opts.tips.length > 0
+      ? `<p style="color:#555;margin:12px 0 8px;">Ideas to improve your matches:</p><ul style="padding-left:20px;color:#444;margin-top:0;">${opts.tips.map((t) => `<li>${escapeHtml(t)}</li>`).join("")}</ul>`
+      : "";
+
+  const first = escapeHtml(opts.displayName.split(" ")[0] || opts.displayName);
+
+  try {
+    await transport.sendMail({
+      from,
+      to: opts.to,
+      subject: "Refresh your job matches on What We Will",
+      html: `
+          <div style="font-family:sans-serif;max-width:520px;margin:0 auto;">
+            <h2 style="margin-bottom:4px;">Hi ${first}</h2>
+            <p style="color:#555;margin-top:0;">
+              Job postings change often. Open <strong>My Tools</strong> and tap
+              <strong>Refresh matches</strong> when you&apos;re ready—matches only update when you run them (we don&apos;t auto-call external APIs for you).
+            </p>
+            ${tipsHtml}
+            <a href="${opts.myToolsUrl}"
+               style="display:inline-block;background:#f97316;color:#fff;padding:10px 22px;border-radius:6px;text-decoration:none;font-weight:600;margin-top:8px;">
+              Open My Tools
+            </a>
+            <p style="margin-top:16px;">
+              <a href="${opts.profileUrl}" style="color:#ea580c;">Update your profile</a>
+              for better results (headline, bio, skills, location).
+            </p>
+            <p style="color:#aaa;font-size:12px;margin-top:24px;">
+              You opted in to these reminders in your profile settings.
+              Turn them off anytime under My Profile.
+            </p>
+          </div>
+        `,
+    });
+    return { ok: true };
+  } catch (err) {
+    console.error("[email] My Tools reminder failed:", err);
+    return { ok: false, reason: "send_failed" };
+  }
+}

--- a/lib/my-tools-reminder-schedule.test.ts
+++ b/lib/my-tools-reminder-schedule.test.ts
@@ -1,0 +1,34 @@
+import {
+  MY_TOOLS_REMINDER_COOLDOWN_DAYS,
+  canSendReminderEmail,
+} from "./my-tools-reminder-schedule";
+
+describe("canSendReminderEmail", () => {
+  const now = new Date("2025-06-15T12:00:00.000Z");
+
+  it("allows send when never sent", () => {
+    expect(canSendReminderEmail(null, now, MY_TOOLS_REMINDER_COOLDOWN_DAYS)).toBe(
+      true
+    );
+  });
+
+  it("blocks send within cooldown window", () => {
+    const recent = new Date("2025-06-14T12:00:00.000Z").toISOString();
+    expect(canSendReminderEmail(recent, now, MY_TOOLS_REMINDER_COOLDOWN_DAYS)).toBe(
+      false
+    );
+  });
+
+  it("allows send after cooldown window", () => {
+    const old = new Date("2025-06-01T12:00:00.000Z").toISOString();
+    expect(canSendReminderEmail(old, now, MY_TOOLS_REMINDER_COOLDOWN_DAYS)).toBe(
+      true
+    );
+  });
+
+  it("respects custom cooldown days", () => {
+    const threeDaysAgo = new Date("2025-06-12T12:00:00.000Z").toISOString();
+    expect(canSendReminderEmail(threeDaysAgo, now, 2)).toBe(true);
+    expect(canSendReminderEmail(threeDaysAgo, now, 5)).toBe(false);
+  });
+});

--- a/lib/my-tools-reminder-schedule.ts
+++ b/lib/my-tools-reminder-schedule.ts
@@ -1,0 +1,18 @@
+/** Default days between My Tools reminder emails per member. */
+export const MY_TOOLS_REMINDER_COOLDOWN_DAYS = 7;
+
+/**
+ * Whether we may send another reminder, comparing ISO timestamps lexicographically
+ * (valid for PostgreSQL/JS ISO strings).
+ */
+export function canSendReminderEmail(
+  lastSentAtIso: string | null,
+  now: Date,
+  cooldownDays: number = MY_TOOLS_REMINDER_COOLDOWN_DAYS
+): boolean {
+  if (!lastSentAtIso) return true;
+  const cutoff = new Date(
+    now.getTime() - cooldownDays * 24 * 60 * 60 * 1000
+  ).toISOString();
+  return lastSentAtIso < cutoff;
+}

--- a/lib/my-tools-reminder-tips.test.ts
+++ b/lib/my-tools-reminder-tips.test.ts
@@ -1,0 +1,25 @@
+import { missingFieldToReminderTip } from "./my-tools-reminder-tips";
+
+describe("missingFieldToReminderTip", () => {
+  it("maps known missing labels", () => {
+    expect(missingFieldToReminderTip("LinkedIn URL")).toBe("Add your LinkedIn URL.");
+    expect(missingFieldToReminderTip("Headline")).toBe("Add a professional headline.");
+    expect(missingFieldToReminderTip("Bio")).toBe(
+      "Add a short career summary to your bio."
+    );
+    expect(missingFieldToReminderTip("Location")).toBe("Add your location.");
+    expect(missingFieldToReminderTip("A longer bio (40+ characters)")).toBe(
+      "Expand your bio to at least 40 characters."
+    );
+  });
+
+  it("lowercases strings starting with At least", () => {
+    expect(missingFieldToReminderTip("At least 2 skills")).toBe(
+      "Add at least 2 skills."
+    );
+  });
+
+  it("falls back for unknown labels", () => {
+    expect(missingFieldToReminderTip("Custom field")).toBe("Complete: Custom field.");
+  });
+});

--- a/lib/my-tools-reminder-tips.ts
+++ b/lib/my-tools-reminder-tips.ts
@@ -1,0 +1,13 @@
+/**
+ * Maps profile completeness `missing` labels → friendly sentences for reminder emails.
+ */
+export function missingFieldToReminderTip(m: string): string {
+  if (m.startsWith("At least")) return `Add ${m.toLowerCase()}.`;
+  if (m === "Bio") return "Add a short career summary to your bio.";
+  if (m === "A longer bio (40+ characters)")
+    return "Expand your bio to at least 40 characters.";
+  if (m === "LinkedIn URL") return "Add your LinkedIn URL.";
+  if (m === "Headline") return "Add a professional headline.";
+  if (m === "Location") return "Add your location.";
+  return `Complete: ${m}.`;
+}

--- a/lib/profile-completeness.test.ts
+++ b/lib/profile-completeness.test.ts
@@ -1,0 +1,119 @@
+import { getProfileCompleteness } from "./profile-completeness";
+
+describe("getProfileCompleteness", () => {
+  it("returns 100 and isStrong when all fields are filled well", () => {
+    const r = getProfileCompleteness({
+      linkedin_url: "https://linkedin.com/in/me",
+      headline: "Engineer",
+      bio: "x".repeat(40),
+      skills: ["React", "Node"],
+      location: "Tulsa, OK",
+    });
+    expect(r.score).toBe(100);
+    expect(r.missing).toEqual([]);
+    expect(r.isStrong).toBe(true);
+  });
+
+  it("marks isStrong false when score below 80", () => {
+    const r = getProfileCompleteness({
+      linkedin_url: null,
+      headline: "Engineer",
+      bio: "x".repeat(40),
+      skills: ["React", "Node"],
+      location: "Tulsa, OK",
+    });
+    expect(r.score).toBe(75);
+    expect(r.missing).toContain("LinkedIn URL");
+    expect(r.isStrong).toBe(false);
+  });
+
+  it("requires at least two non-empty skills", () => {
+    const r = getProfileCompleteness({
+      linkedin_url: "https://linkedin.com/in/me",
+      headline: "Engineer",
+      bio: "x".repeat(40),
+      skills: ["OnlyOne"],
+      location: "OK",
+    });
+    expect(r.missing).toContain("At least 2 skills");
+    expect(r.score).toBe(85);
+  });
+
+  it("ignores whitespace-only skills", () => {
+    const r = getProfileCompleteness({
+      linkedin_url: "https://linkedin.com/in/me",
+      headline: "Engineer",
+      bio: "x".repeat(40),
+      skills: ["A", "   ", "B"],
+      location: "OK",
+    });
+    expect(r.missing).not.toContain("At least 2 skills");
+  });
+
+  it("gives partial bio credit and flags short bio", () => {
+    const r = getProfileCompleteness({
+      linkedin_url: "https://linkedin.com/in/me",
+      headline: "Engineer",
+      bio: "short",
+      skills: ["A", "B"],
+      location: "OK",
+    });
+    expect(r.missing).toContain("A longer bio (40+ characters)");
+    expect(r.score).toBe(87);
+  });
+
+  it("treats empty bio as missing Bio", () => {
+    const r = getProfileCompleteness({
+      linkedin_url: "https://linkedin.com/in/me",
+      headline: "Engineer",
+      bio: null,
+      skills: ["A", "B"],
+      location: "OK",
+    });
+    expect(r.missing).toContain("Bio");
+  });
+
+  it("trims linkedin_url and headline", () => {
+    const r = getProfileCompleteness({
+      linkedin_url: "  https://linkedin.com/in/me  ",
+      headline: "  Title  ",
+      bio: "x".repeat(40),
+      skills: ["A", "B"],
+      location: "OK",
+    });
+    expect(r.missing).toEqual([]);
+    expect(r.isStrong).toBe(true);
+  });
+
+  it("accumulates multiple missing fields for sparse profile", () => {
+    const r = getProfileCompleteness({
+      linkedin_url: null,
+      headline: null,
+      bio: null,
+      skills: [],
+      location: null,
+    });
+    expect(r.score).toBe(0);
+    expect(r.missing).toEqual(
+      expect.arrayContaining([
+        "LinkedIn URL",
+        "Headline",
+        "Bio",
+        "At least 2 skills",
+        "Location",
+      ])
+    );
+    expect(r.isStrong).toBe(false);
+  });
+
+  it("caps score at 100 if weights overflow", () => {
+    const r = getProfileCompleteness({
+      linkedin_url: "https://l.com/x",
+      headline: "H",
+      bio: "x".repeat(100),
+      skills: ["a", "b", "c"],
+      location: "Here",
+    });
+    expect(r.score).toBeLessThanOrEqual(100);
+  });
+});

--- a/lib/profile-completeness.ts
+++ b/lib/profile-completeness.ts
@@ -1,0 +1,73 @@
+/**
+ * Fields that feed Pulsar match/brief payloads (see my-tools/actions buildProfilePayload).
+ * Used for in-app nudges to improve match quality.
+ */
+export type ProfileCompletenessInput = {
+  headline: string | null;
+  bio: string | null;
+  skills: string[] | null;
+  linkedin_url: string | null;
+  location: string | null;
+};
+
+export type ProfileCompleteness = {
+  /** 0–100 */
+  score: number;
+  /** Human-readable missing items (for UI / email copy). */
+  missing: string[];
+  /** Convenience: score >= 80 */
+  isStrong: boolean;
+};
+
+const MIN_SKILLS = 2;
+
+/**
+ * Weighted score aligned with how much each field helps matching.
+ */
+export function getProfileCompleteness(
+  p: ProfileCompletenessInput
+): ProfileCompleteness {
+  const missing: string[] = [];
+  let score = 0;
+
+  if (p.linkedin_url?.trim()) {
+    score += 25;
+  } else {
+    missing.push("LinkedIn URL");
+  }
+
+  if (p.headline?.trim()) {
+    score += 20;
+  } else {
+    missing.push("Headline");
+  }
+
+  if (p.bio?.trim() && p.bio.trim().length >= 40) {
+    score += 25;
+  } else if (p.bio?.trim()) {
+    score += 12;
+    missing.push("A longer bio (40+ characters)");
+  } else {
+    missing.push("Bio");
+  }
+
+  const skillCount = (p.skills ?? []).filter((s) => s.trim().length > 0).length;
+  if (skillCount >= MIN_SKILLS) {
+    score += 15;
+  } else {
+    missing.push(`At least ${MIN_SKILLS} skills`);
+  }
+
+  if (p.location?.trim()) {
+    score += 15;
+  } else {
+    missing.push("Location");
+  }
+
+  const capped = Math.min(100, score);
+  return {
+    score: capped,
+    missing,
+    isStrong: capped >= 80,
+  };
+}

--- a/lib/pulsar/client.ts
+++ b/lib/pulsar/client.ts
@@ -1,0 +1,62 @@
+import {
+  WhatWeWillBriefRequest,
+  WhatWeWillBriefResponse,
+  WhatWeWillMatchResponse,
+  WhatWeWillProfileRequest,
+} from "./types";
+
+function getPulsarConfig() {
+  const baseUrl = process.env.PULSAR_BASE_URL;
+  const apiKey = process.env.WHATWEWILL_API_KEY;
+
+  if (!baseUrl) {
+    throw new Error("PULSAR_BASE_URL is not configured");
+  }
+  if (!apiKey) {
+    throw new Error("WHATWEWILL_API_KEY is not configured");
+  }
+
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    apiKey,
+  };
+}
+
+async function postJson<TResponse>(path: string, payload: unknown): Promise<TResponse> {
+  const { baseUrl, apiKey } = getPulsarConfig();
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+    },
+    body: JSON.stringify(payload),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const bodyText = await res.text();
+    throw new Error(`Pulsar request failed (${res.status}): ${bodyText}`);
+  }
+
+  return (await res.json()) as TResponse;
+}
+
+export async function fetchPulsarMatches(
+  payload: WhatWeWillProfileRequest
+): Promise<WhatWeWillMatchResponse> {
+  return postJson<WhatWeWillMatchResponse>(
+    "/api/integrations/whatwewill/match",
+    payload
+  );
+}
+
+export async function fetchPulsarBrief(
+  payload: WhatWeWillBriefRequest
+): Promise<WhatWeWillBriefResponse> {
+  return postJson<WhatWeWillBriefResponse>(
+    "/api/integrations/whatwewill/brief",
+    payload
+  );
+}
+

--- a/lib/pulsar/types.ts
+++ b/lib/pulsar/types.ts
@@ -1,0 +1,46 @@
+export type PreferredWorkType = "remote" | "hybrid" | "onsite";
+
+export type WhatWeWillProfileRequest = {
+  personId: string;
+  linkedinUrl?: string;
+  resumeText?: string;
+  resumeUrl?: string;
+  skills: string[];
+  experienceSummary?: string;
+  interestedIndustries: string[];
+  interestedRoleTitles: string[];
+  preferredWorkTypes: PreferredWorkType[];
+  preferredLocations: string[];
+};
+
+export type WhatWeWillMatch = {
+  score: number;
+  label: "Strong match" | "Good match" | "Stretch";
+  roleTitle: string;
+  company: string;
+  location: string;
+  source: "greenhouse" | "lever";
+  reasons: string[];
+  concern?: string;
+  applyUrl: string;
+};
+
+export type WhatWeWillMatchResponse = {
+  requestId: string;
+  candidateSummary: string;
+  matches: WhatWeWillMatch[];
+};
+
+export type WhatWeWillBriefRequest = WhatWeWillProfileRequest & {
+  tone?: "supportive" | "direct" | "coach";
+  maxWords?: number;
+  includeIllustrativeLinks?: boolean;
+};
+
+export type WhatWeWillBriefResponse = {
+  requestId: string;
+  markdown: string;
+  model: string;
+  generatedAt: string;
+};
+

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,9 @@ export interface Profile {
   approval_status: ApprovalStatus;
   role: ProfileRole;
   last_seen_at: string | null;
+  /** Opt-in: weekly My Tools reminder email (cron). Default false. */
+  email_my_tools_reminders: boolean;
+  last_my_tools_reminder_sent_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -39,6 +42,7 @@ export interface ProfileInsert {
   timezone?: string;
   is_onboarded?: boolean;
   role?: ProfileRole;
+  email_my_tools_reminders?: boolean;
 }
 
 export interface ProfileUpdate {
@@ -55,6 +59,7 @@ export interface ProfileUpdate {
   portfolio_url?: string | null;
   timezone?: string;
   is_onboarded?: boolean;
+  email_my_tools_reminders?: boolean;
 }
 
 // ─── Messaging ───────────────────────────────────────────────────────────────

--- a/supabase/migrations/057_my_tools_pulsar.sql
+++ b/supabase/migrations/057_my_tools_pulsar.sql
@@ -1,0 +1,48 @@
+-- Persisted outputs for Pulsar-powered My Tools features.
+
+CREATE TABLE IF NOT EXISTS public.member_match_runs (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  request_id        TEXT NOT NULL,
+  candidate_summary TEXT NOT NULL,
+  matches           JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.member_match_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own match runs"
+  ON public.member_match_runs FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Users can create own match runs"
+  ON public.member_match_runs FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE INDEX IF NOT EXISTS idx_member_match_runs_user_created
+  ON public.member_match_runs (user_id, created_at DESC);
+
+
+CREATE TABLE IF NOT EXISTS public.member_career_briefs (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  request_id   TEXT NOT NULL,
+  markdown     TEXT NOT NULL,
+  model        TEXT NOT NULL,
+  generated_at TIMESTAMPTZ NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.member_career_briefs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own career briefs"
+  ON public.member_career_briefs FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Users can create own career briefs"
+  ON public.member_career_briefs FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE INDEX IF NOT EXISTS idx_member_career_briefs_user_created
+  ON public.member_career_briefs (user_id, created_at DESC);
+

--- a/supabase/migrations/058_profile_my_tools_email_prefs.sql
+++ b/supabase/migrations/058_profile_my_tools_email_prefs.sql
@@ -1,0 +1,11 @@
+-- Opt-in weekly email nudges for My Tools (profile completeness / manual refresh reminder).
+-- Does not trigger Pulsar calls; cron only sends email.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS email_my_tools_reminders BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS last_my_tools_reminder_sent_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.profiles.email_my_tools_reminders IS
+  'Member opt-in: periodic email with link to My Tools / profile (no automatic API refresh).';
+COMMENT ON COLUMN public.profiles.last_my_tools_reminder_sent_at IS
+  'Rate-limits reminder emails (e.g. weekly) from the cron job.';

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/my-tools-reminders",
+      "schedule": "0 15 * * 1"
+    }
+  ]
+}


### PR DESCRIPTION
Profile completeness nudges + optional weekly My Tools email reminders

### Summary
Builds on My Tools / Pulsar integration with in-app guidance, optional email reminders (no automatic Pulsar calls), and documentation for how refresh/cost works.

### In-app

- Profile completeness on My Tools (0–100) from headline, bio (length), skills count, location, LinkedIn—aligned with the Pulsar payload.
- Banner when score &lt; 80 with missing fields + link to My Profile.
- Stale matches note when the last match run is ≥ 7 days old; empty state copy nudges profile enrichment.

### Email & cron

- Shared lib/email.ts (Gmail via GMAIL_USER / GMAIL_APP_PASSWORD); DM notifications in app/api/messages/route.ts refactored to use it (behavior unchanged).
- Opt-in on My Profile: “Email me a weekly reminder…” (default off).
- Migration 058_profile_my_tools_email_prefs.sql: email_my_tools_reminders, last_my_tools_reminder_sent_at.
- GET /api/cron/my-tools-reminders: secured with Authorization: Bearer ${CRON_SECRET}; 7-day cooldown per member; max 40 sends per run; only approved, onboarded, opted-in users; updates last_my_tools_reminder_sent_at after send.
- vercel.json: weekly cron (Mondays 15:00 UTC).

**Docs**

- docs/mytools-refresh.md: user-triggered Pulsar refresh, no batch auto-refresh by design, cost notes, env vars, deploy checklist.
- README.md: Gmail + cron + service role env section; My Tools row in feature table.

**Types / misc**

- Profile (+ related types) and ConversationView stub profile updated for new fields.

**Deploy notes**

- Run Supabase migration 058.
- Set CRON_SECRET, SUPABASE_SERVICE_ROLE_KEY, NEXT_PUBLIC_SITE_URL, and Gmail vars on Vercel (cron availability may depend on Vercel plan).