### PR TITLE
feat: add admin-managed News publishing flow

### DIFF
--- a/app/(app)/admin/news/actions.ts
+++ b/app/(app)/admin/news/actions.ts
@@ -1,0 +1,106 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+function toSlug(input: string) {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80);
+}
+
+async function requireAdmin() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) throw new Error("Not authenticated");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (profile?.role !== "admin") throw new Error("Not authorized");
+
+  return { supabase, userId: user.id };
+}
+
+export async function createNewsPost(formData: FormData) {
+  const { supabase, userId } = await requireAdmin();
+
+  const title = String(formData.get("title") ?? "").trim();
+  const excerpt = String(formData.get("excerpt") ?? "").trim();
+  const content = String(formData.get("content") ?? "").trim();
+  const slugInput = String(formData.get("slug") ?? "").trim();
+  const isPublished = formData.get("is_published") === "on";
+  const coverImageUrl = String(formData.get("cover_image_url") ?? "").trim();
+
+  if (!title || !content) {
+    throw new Error("Title and content are required.");
+  }
+
+  const slug = toSlug(slugInput || title);
+  if (!slug) throw new Error("Please provide a valid slug or title.");
+
+  const nowIso = new Date().toISOString();
+
+  const { error } = await supabase.from("news_posts").insert({
+    title,
+    slug,
+    excerpt: excerpt || null,
+    content,
+    is_published: isPublished,
+    published_at: isPublished ? nowIso : null,
+    cover_image_url: coverImageUrl || null,
+    created_by: userId,
+  });
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath("/admin/news");
+  revalidatePath("/news");
+  revalidatePath("/");
+}
+
+export async function deleteNewsPost(formData: FormData) {
+  const { supabase } = await requireAdmin();
+  const id = String(formData.get("id") ?? "");
+  if (!id) throw new Error("Missing post id.");
+
+  const { error } = await supabase.from("news_posts").delete().eq("id", id);
+  if (error) throw new Error(error.message);
+
+  revalidatePath("/admin/news");
+  revalidatePath("/news");
+  revalidatePath("/");
+}
+
+export async function togglePublishNewsPost(formData: FormData) {
+  const { supabase } = await requireAdmin();
+  const id = String(formData.get("id") ?? "");
+  const publish = String(formData.get("publish") ?? "") === "true";
+  if (!id) throw new Error("Missing post id.");
+
+  const { error } = await supabase
+    .from("news_posts")
+    .update({
+      is_published: publish,
+      published_at: publish ? new Date().toISOString() : null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id);
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath("/admin/news");
+  revalidatePath("/news");
+  revalidatePath("/");
+}

--- a/app/(app)/admin/news/page.tsx
+++ b/app/(app)/admin/news/page.tsx
@@ -1,0 +1,125 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { createNewsPost, deleteNewsPost, togglePublishNewsPost } from "./actions";
+
+export default async function AdminNewsPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (profile?.role !== "admin") redirect("/dashboard");
+
+  const { data: posts } = await supabase
+    .from("news_posts")
+    .select("id, title, slug, excerpt, is_published, published_at, created_at")
+    .order("created_at", { ascending: false });
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 py-2">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">News Admin</h1>
+        <p className="text-sm text-muted-foreground">
+          Publish front-page updates in a blog-style format.
+        </p>
+      </div>
+
+      <section className="rounded-xl border p-4 sm:p-6">
+        <h2 className="text-lg font-medium">Create News Post</h2>
+        <form action={createNewsPost} className="mt-4 space-y-3">
+          <Input name="title" placeholder="Title" required />
+          <Input name="slug" placeholder="Slug (optional, auto-generated from title)" />
+          <Textarea
+            name="excerpt"
+            placeholder="Short excerpt (optional)"
+            className="min-h-20"
+          />
+          <Textarea
+            name="content"
+            placeholder="Write update content in markdown..."
+            className="min-h-40"
+            required
+          />
+          <Input
+            name="cover_image_url"
+            placeholder="Cover image URL (optional)"
+            type="url"
+          />
+          <label className="flex items-center gap-2 text-sm">
+            <input name="is_published" type="checkbox" />
+            Publish immediately
+          </label>
+          <Button type="submit">Create post</Button>
+        </form>
+      </section>
+
+      <section className="rounded-xl border">
+        <div className="border-b px-4 py-3">
+          <h2 className="text-lg font-medium">Existing Posts</h2>
+        </div>
+        <div className="divide-y">
+          {(posts ?? []).length === 0 ? (
+            <p className="px-4 py-6 text-sm text-muted-foreground">No posts yet.</p>
+          ) : (
+            (posts ?? []).map((post) => (
+              <div key={post.id} className="flex flex-col gap-3 px-4 py-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <p className="font-medium">{post.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    /news/{post.slug} · {post.is_published ? "Published" : "Draft"}
+                  </p>
+                  {post.excerpt && (
+                    <p className="text-sm text-muted-foreground">{post.excerpt}</p>
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    Created {new Date(post.created_at).toLocaleDateString()}
+                    {post.published_at
+                      ? ` · Published ${new Date(post.published_at).toLocaleDateString()}`
+                      : ""}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Link href={`/news/${post.slug}`} target="_blank">
+                    <Button variant="outline" size="sm">
+                      View
+                    </Button>
+                  </Link>
+                  <form action={togglePublishNewsPost}>
+                    <input type="hidden" name="id" value={post.id} />
+                    <input
+                      type="hidden"
+                      name="publish"
+                      value={post.is_published ? "false" : "true"}
+                    />
+                    <Button variant="outline" size="sm" type="submit">
+                      {post.is_published ? "Unpublish" : "Publish"}
+                    </Button>
+                  </form>
+                  <form action={deleteNewsPost}>
+                    <input type="hidden" name="id" value={post.id} />
+                    <Button variant="destructive" size="sm" type="submit">
+                      Delete
+                    </Button>
+                  </form>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(app)/app-shell.tsx
+++ b/app/(app)/app-shell.tsx
@@ -14,6 +14,7 @@ import {
   Menu,
   LogOut,
   ShieldCheck,
+  Newspaper,
   Briefcase,
   ClipboardList,
   Link2,
@@ -240,6 +241,14 @@ export default function AppShell({ children, user }: AppShellProps) {
             {user.isAdmin && (
               <>
                 <Separator className="my-2" />
+                <Link
+                  href="/admin/news"
+                  onClick={() => setSidebarOpen(false)}
+                  className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                >
+                  <Newspaper className="size-5 shrink-0" />
+                  News
+                </Link>
                 <Link
                   href="/admin/approvals"
                   onClick={() => setSidebarOpen(false)}

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -1,0 +1,61 @@
+import { notFound } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function NewsDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let isAdmin = false;
+  if (user) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .single();
+    isAdmin = profile?.role === "admin";
+  }
+
+  let query = supabase
+    .from("news_posts")
+    .select("title, excerpt, content, cover_image_url, is_published, published_at, created_at")
+    .eq("slug", slug);
+
+  if (!isAdmin) query = query.eq("is_published", true);
+
+  const { data: post } = await query.maybeSingle();
+  if (!post) notFound();
+
+  return (
+    <article className="mx-auto max-w-3xl px-4 py-12">
+      <h1 className="text-3xl font-semibold">{post.title}</h1>
+      <p className="mt-2 text-xs text-muted-foreground">
+        {new Date(post.published_at ?? post.created_at).toLocaleDateString()}
+        {!post.is_published ? " · Draft" : ""}
+      </p>
+      {post.excerpt ? (
+        <p className="mt-4 text-base text-muted-foreground">{post.excerpt}</p>
+      ) : null}
+      {post.cover_image_url ? (
+        // Plain img keeps this flexible for external image URLs.
+        <img
+          src={post.cover_image_url}
+          alt=""
+          className="mt-6 w-full rounded-lg border object-cover"
+        />
+      ) : null}
+      <div className="prose prose-neutral mt-8 max-w-none">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{post.content}</ReactMarkdown>
+      </div>
+    </article>
+  );
+}

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function NewsPage() {
+  const supabase = await createClient();
+
+  const { data: posts } = await supabase
+    .from("news_posts")
+    .select("id, title, slug, excerpt, published_at, created_at")
+    .eq("is_published", true)
+    .order("published_at", { ascending: false, nullsFirst: false });
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-12">
+      <h1 className="text-3xl font-semibold">News</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Updates from What We Will.
+      </p>
+
+      <div className="mt-8 space-y-4">
+        {(posts ?? []).length === 0 ? (
+          <p className="text-sm text-muted-foreground">No news posts yet.</p>
+        ) : (
+          (posts ?? []).map((post) => (
+            <article key={post.id} className="rounded-xl border p-5">
+              <h2 className="text-xl font-semibold">
+                <Link href={`/news/${post.slug}`} className="hover:underline">
+                  {post.title}
+                </Link>
+              </h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {new Date(post.published_at ?? post.created_at).toLocaleDateString()}
+              </p>
+              {post.excerpt ? (
+                <p className="mt-3 text-sm text-muted-foreground">{post.excerpt}</p>
+              ) : null}
+              <Link href={`/news/${post.slug}`} className="mt-4 inline-block text-sm font-medium text-primary hover:underline">
+                Read more
+              </Link>
+            </article>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/landing/landing-nav.tsx
+++ b/components/landing/landing-nav.tsx
@@ -80,10 +80,10 @@ export function LandingNav({ user }: { user?: User | null }) {
             </Link>
 
             <Link
-              href="/#our-future"
+              href="/news"
               className="text-sm font-medium text-foreground transition-colors hover:text-primary-orange"
             >
-              Our Future
+              News
             </Link>
           </nav>
 
@@ -229,11 +229,11 @@ export function LandingNav({ user }: { user?: User | null }) {
             </Link>
 
             <Link
-              href="/#our-future"
+              href="/news"
               className="text-sm font-medium text-foreground transition-colors hover:text-primary-orange"
               onClick={() => setIsMobileMenuOpen(false)}
             >
-              Our Future
+              News
             </Link>
           </nav>
         </div>

--- a/supabase/migrations/058_news_posts.sql
+++ b/supabase/migrations/058_news_posts.sql
@@ -1,0 +1,54 @@
+-- News posts for landing page/blog-style updates.
+
+CREATE TABLE public.news_posts (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title           TEXT NOT NULL,
+  slug            TEXT NOT NULL UNIQUE,
+  excerpt         TEXT,
+  content         TEXT NOT NULL,
+  is_published    BOOLEAN NOT NULL DEFAULT false,
+  published_at    TIMESTAMPTZ,
+  cover_image_url TEXT,
+  created_by      UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.news_posts ENABLE ROW LEVEL SECURITY;
+
+-- Published news is visible to everyone; admins can read all drafts too.
+CREATE POLICY "Published news is publicly readable"
+  ON public.news_posts
+  FOR SELECT
+  TO anon, authenticated
+  USING (
+    is_published = true
+    OR (SELECT role FROM public.profiles WHERE id = auth.uid()) = 'admin'
+  );
+
+CREATE POLICY "Admins can create news"
+  ON public.news_posts
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    (SELECT role FROM public.profiles WHERE id = auth.uid()) = 'admin'
+  );
+
+CREATE POLICY "Admins can update news"
+  ON public.news_posts
+  FOR UPDATE
+  TO authenticated
+  USING (
+    (SELECT role FROM public.profiles WHERE id = auth.uid()) = 'admin'
+  )
+  WITH CHECK (
+    (SELECT role FROM public.profiles WHERE id = auth.uid()) = 'admin'
+  );
+
+CREATE POLICY "Admins can delete news"
+  ON public.news_posts
+  FOR DELETE
+  TO authenticated
+  USING (
+    (SELECT role FROM public.profiles WHERE id = auth.uid()) = 'admin'
+  );


### PR DESCRIPTION
Create an admin-only News editor in the members platform with publish controls, add public news listing/detail pages, and update landing navigation from Our Future to News.