### PR TITLE
feat: add sticky styling to profile, logout section in app-shell

### DIFF
--- a/app/(app)/app-shell.tsx
+++ b/app/(app)/app-shell.tsx
@@ -252,7 +252,7 @@ export default function AppShell({ children, user }: AppShellProps) {
             )}
           </nav>
 
-          <div className="border-t p-4">
+          <div className="sticky bottom-0 z-30 border-t bg-background p-4">
             <div className="flex items-center gap-3 rounded-lg px-3 py-2">
               <UserAvatar
                 avatarUrl={user.avatarUrl}


### PR DESCRIPTION
Asana: https://app.asana.com/1/1213515485882011/project/1213516055535837/task/1213904250386259?focus=true

UI/UX improvement on Dashboard and other pages where left nav is present from app-shell. 

Currently profile icon + details, bug reporting and logout buttons are all fixed at the extreme bottom of the left nav pane. 

Would be better UX (at least for now while we don't have too many nav options) to stick it to the bottom of the screen within the nav pane.

Before:
<img width="1919" height="928" alt="image" src="https://github.com/user-attachments/assets/7ed3d83e-707b-448c-8cd5-b6abb9bc892a" />

After:
<img width="1929" height="931" alt="image" src="https://github.com/user-attachments/assets/092193ea-d895-4a1a-8cb5-29811652d083" />