### PR TITLE
Messagetrash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ ACTION_NETWORK_API_KEY=
 # Server-side only — never expose as NEXT_PUBLIC_.
 GOOGLE_FORM_SHARE_YOUR_STORY_URL=
 
+
+# .env.local
+ACTION_NETWORK_API_KEY=smurf
+SUPABASE_URL=smurf
+SUPABASE_ANON_KEY=smurf

--- a/app/ConversationList_test/page.tsx
+++ b/app/ConversationList_test/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { ConversationList } from "@/components/messages/ConversationList";
+import type { ConversationWithDetails, Message, Profile } from "@/lib/types";
+
+// Mock utility functions
+const formatRelativeTime = (date: string) =>
+  new Date(date).toLocaleTimeString();
+const getAvatarColor = (_name: string) => "bg-blue-500 text-white";
+const LiveStatusAvatar = ({
+  avatarUrl,
+  displayName,
+}: {
+  avatarUrl: string | null;
+  displayName: string;
+}) => (
+  <div className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center text-xs">
+    {displayName[0]}
+  </div>
+);
+
+export default function MockConversationList() {
+  const currentUserId = "user_1";
+  const selfNotesId = "notes_1";
+
+  const initialConversations: ConversationWithDetails[] = [
+    // My Notes
+    {
+      conversation: {
+        id: selfNotesId,
+        type: "dm",
+        group_id: null,
+        created_at: new Date().toISOString(),
+      },
+      participants: [],
+      lastMessage: {
+        id: "msg_0",
+        conversation_id: selfNotesId,
+        sender_id: currentUserId,
+        content: "Remember to mock this component!",
+        created_at: new Date().toISOString(),
+        message_type: "system",
+        metadata: {},
+        edited_at: null,
+      },
+      unreadCount: 0,
+    },
+    // DM with Alice
+    {
+      conversation: {
+        id: "conv_2",
+        type: "dm",
+        group_id: null,
+        created_at: new Date().toISOString(),
+      },
+      participants: [
+        {
+          id: "user_2",
+          display_name: "Alice",
+          avatar_url: null,
+          resume_path: null,
+          headline: null,
+          bio: null,
+          location: null,
+          skills: [],
+          open_to_referrals: true,
+          linkedin_url: null,
+          github_url: null,
+          portfolio_url: null,
+          timezone: "UTC",
+          is_onboarded: true,
+          approval_status: "approved",
+          role: "member",
+          last_seen_at: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ],
+      lastMessage: {
+        id: "msg_1",
+        conversation_id: "conv_2",
+        sender_id: "user_2",
+        content: "Hey there!",
+        created_at: new Date().toISOString(),
+        message_type: "text",
+        metadata: {},
+        edited_at: null,
+      },
+      unreadCount: 1,
+    },
+    // DM with Bob
+    {
+      conversation: {
+        id: "conv_3",
+        type: "dm",
+        group_id: null,
+        created_at: new Date().toISOString(),
+      },
+      participants: [
+        {
+          id: "user_3",
+          display_name: "Bob",
+          avatar_url: null,
+          resume_path: null,
+          headline: null,
+          bio: null,
+          location: null,
+          skills: [],
+          open_to_referrals: true,
+          linkedin_url: null,
+          github_url: null,
+          portfolio_url: null,
+          timezone: "UTC",
+          is_onboarded: true,
+          approval_status: "approved",
+          role: "member",
+          last_seen_at: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ],
+      lastMessage: {
+        id: "msg_2",
+        conversation_id: "conv_3",
+        sender_id: currentUserId,
+        content: "Hi Bob, how are you?",
+        created_at: new Date().toISOString(),
+        message_type: "text",
+        metadata: {},
+        edited_at: null,
+      },
+      unreadCount: 0,
+    },
+    // Group conversation (will be filtered out in your component)
+    {
+      conversation: {
+        id: "group_1",
+        type: "group",
+        group_id: "group_1",
+        created_at: new Date().toISOString(),
+      },
+      participants: [],
+      lastMessage: {
+        id: "msg_3",
+        conversation_id: "group_1",
+        sender_id: "user_2",
+        content: "Welcome to the group!",
+        created_at: new Date().toISOString(),
+        message_type: "text",
+        metadata: {},
+        edited_at: null,
+      },
+      unreadCount: 2,
+      groupName: "Study Group",
+      groupSlug: "study-group",
+    },
+  ];
+
+  return (
+    <div className="h-screen w-80 border">
+      <ConversationList
+        initialConversations={initialConversations}
+        currentUserId={currentUserId}
+        selfNotesId={selfNotesId}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/ErrorCard.tsx
+++ b/components/dashboard/ErrorCard.tsx
@@ -1,0 +1,22 @@
+type ErrorCardProps = {
+  message: string | null; // can be string or null
+};
+
+export default function ErrorCard({ message }: ErrorCardProps) {
+  if (!message) return null;
+
+  return (
+    <div
+      style={{
+        backgroundColor: "#fee2e2",
+        border: "1px solid #f87171",
+        color: "#b91c1c",
+        padding: "12px",
+        borderRadius: "6px",
+        marginBottom: "10px",
+      }}
+    >
+      {message}
+    </div>
+  );
+}

--- a/components/messages/ConversationList.tsx
+++ b/components/messages/ConversationList.tsx
@@ -6,11 +6,10 @@ import { usePathname, useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
 import { LiveStatusAvatar } from "@/components/shared/LiveStatusAvatar";
-import { getAvatarColor } from "@/lib/utils/avatar";
 import { formatRelativeTime } from "@/lib/utils/time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { UsersRound, Archive, Video, BookMarked, Trash } from "lucide-react";
+import { BookMarked, Archive, Trash, Video } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -42,7 +41,7 @@ export function ConversationList({
       .join(","),
   );
 
-  // Sync from server when initialConversations gains new conversations (e.g. after starting a new thread + refresh)
+  // Sync from server when initialConversations gains new conversations
   useEffect(() => {
     const ids = initialConversations
       .map((c) => c.conversation.id)
@@ -66,14 +65,12 @@ export function ConversationList({
     );
   }, [pathname]);
 
-  // Subscribe to new messages for real-time list updates
+  // Subscribe to new messages for real-time updates
   useEffect(() => {
     const supabase = createClient();
 
     const channel = supabase
       .channel("conversation-list")
-      // When the current user is added to a new conversation (new DM or group),
-      // refresh the server data so the thread appears in the sidebar immediately.
       .on(
         "postgres_changes",
         {
@@ -97,7 +94,6 @@ export function ConversationList({
               (c) => c.conversation.id === newMsg.conversation_id,
             );
 
-            // Unknown conversation — refresh from server as a fallback.
             if (idx === -1) {
               router.refresh();
               return prev;
@@ -150,6 +146,12 @@ export function ConversationList({
     e.preventDefault();
     e.stopPropagation();
 
+    const confirmed = window.confirm(
+      "Are you sure you want to permanently delete this conversation?",
+    );
+
+    if (!confirmed) return;
+
     const supabase = createClient();
     await supabase.from("conversations").delete().eq("id", conversationId);
 
@@ -160,8 +162,14 @@ export function ConversationList({
     if (pathname === `/messages/${conversationId}`) {
       router.push("/messages");
     }
+
     router.refresh();
   }
+
+  // Only show DMs + notes
+  const dmConversations = conversations.filter(
+    (c) => c.conversation.id !== selfNotesId && c.conversation.type !== "group",
+  );
 
   return (
     <div className="flex h-full flex-col">
@@ -173,7 +181,7 @@ export function ConversationList({
 
       {/* List */}
       <div className="flex-1 overflow-y-auto">
-        {/* My Notes — always pinned at top */}
+        {/* My Notes */}
         {(() => {
           const isNotesActive = pathname === `/messages/${selfNotesId}`;
           const notesConv = conversations.find(
@@ -208,8 +216,7 @@ export function ConversationList({
           );
         })()}
 
-        {conversations.filter((c) => c.conversation.id !== selfNotesId)
-          .length === 0 ? (
+        {dmConversations.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-40 text-center px-6">
             <p className="text-sm text-muted-foreground">
               No conversations yet.
@@ -219,244 +226,128 @@ export function ConversationList({
             </p>
           </div>
         ) : (
-          conversations
-            .filter((c) => c.conversation.id !== selfNotesId)
-            .map(
-              ({
-                conversation,
-                participants,
-                lastMessage,
-                unreadCount,
-                groupName,
-                groupSlug,
-              }) => {
-                const isActive = pathname === `/messages/${conversation.id}`;
-                const hasUnread = unreadCount > 0;
-                const isGroupConv = conversation.type === "group";
+          dmConversations.map(
+            ({ conversation, participants, lastMessage, unreadCount }) => {
+              const otherUser = participants[0];
+              if (!otherUser) return null;
+              const isActive = pathname === `/messages/${conversation.id}`;
+              const hasUnread = unreadCount > 0;
+              const isPendingCall =
+                lastMessage?.message_type === "video_invite" &&
+                lastMessage.sender_id !== currentUserId;
 
-                const isPendingCall =
-                  lastMessage?.message_type === "video_invite" &&
-                  lastMessage.sender_id !== currentUserId;
-
-                if (isGroupConv) {
-                  return (
-                    <div
-                      key={conversation.id}
-                      className={cn(
-                        "flex items-center gap-1 border-b px-4 py-3 transition-colors hover:bg-accent",
-                        isActive && "bg-accent",
-                      )}
-                    >
-                      <Link
-                        href={`/messages/${conversation.id}`}
-                        className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
-                      >
-                        {/* Group icon avatar */}
-                        <div className="relative shrink-0">
-                          <div
-                            className={cn(
-                              "flex size-10 items-center justify-center rounded-full text-white text-sm font-semibold",
-                              getAvatarColor(groupName ?? "Group"),
-                            )}
-                          >
-                            <UsersRound className="size-4" />
-                          </div>
-                        </div>
-
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="flex items-center gap-1.5 min-w-0">
-                              <p
-                                className={cn(
-                                  "text-sm truncate",
-                                  hasUnread ? "font-semibold" : "font-medium",
-                                )}
-                              >
-                                {groupName ?? "Group"}
-                              </p>
-                              <Badge
-                                variant="secondary"
-                                className="shrink-0 text-[10px] px-1.5 py-0 h-4"
-                              >
-                                Group
-                              </Badge>
-                            </div>
-                            {lastMessage && (
-                              <span className="text-[11px] text-muted-foreground shrink-0">
-                                {formatRelativeTime(lastMessage.created_at)}
-                              </span>
-                            )}
-                          </div>
-
-                          <div className="flex items-center justify-between gap-2 mt-0.5">
-                            <p
-                              className={cn(
-                                "text-xs truncate",
-                                hasUnread
-                                  ? "font-medium text-foreground"
-                                  : "text-muted-foreground",
-                              )}
-                            >
-                              {lastMessage
-                                ? lastMessage.message_type === "system"
-                                  ? lastMessage.content
-                                  : lastMessage.message_type === "video_invite"
-                                    ? lastMessage.sender_id === currentUserId
-                                      ? "You started a video call"
-                                      : "Incoming video call"
-                                    : `${lastMessage.sender_id === currentUserId ? "You: " : ""}${lastMessage.content}`
-                                : "No messages yet"}
-                            </p>
-                            {isPendingCall ? (
-                              <span className="shrink-0 flex items-center gap-1 rounded-full bg-green-500 text-white px-2 py-0.5 text-[10px] font-semibold animate-pulse">
-                                <Video className="size-3" />
-                                Incoming call
-                              </span>
-                            ) : hasUnread ? (
-                              <Badge
-                                variant="destructive"
-                                className="shrink-0 h-4 min-w-4 px-1 text-[10px] flex items-center justify-center"
-                              >
-                                {unreadCount > 99 ? "99+" : unreadCount}
-                              </Badge>
-                            ) : null}
-                          </div>
-                        </div>
-                      </Link>
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger
-                            asChild
-                            onClick={(e) => handleArchive(e, conversation.id)}
-                          >
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="size-8 shrink-0"
-                            >
-                              <Archive className="size-4" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>Archive conversation</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger
-                            asChild
-                            onClick={(e) => handleDelete(e, conversation.id)}
-                          >
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="size-8 shrink-0"
-                            >
-                              <Trash className="size-4" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>Delete conversation</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </div>
-                  );
-                }
-
-                // DM row
-                const otherUser = participants[0];
-                if (!otherUser) return null;
-
-                return (
-                  <div
-                    key={conversation.id}
-                    className={cn(
-                      "flex items-center gap-1 border-b px-4 py-3 transition-colors hover:bg-accent",
-                      isActive && "bg-accent",
-                    )}
+              return (
+                <div
+                  key={conversation.id}
+                  className={cn(
+                    "flex items-center gap-1 border-b px-4 py-3 transition-colors hover:bg-accent",
+                    isActive && "bg-accent",
+                  )}
+                >
+                  <Link
+                    href={`/messages/${conversation.id}`}
+                    className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
                   >
-                    <Link
-                      href={`/messages/${conversation.id}`}
-                      className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
-                    >
-                      <LiveStatusAvatar
-                        avatarUrl={otherUser.avatar_url ?? null}
-                        displayName={otherUser.display_name}
-                        size="md"
-                        lastSeenAt={otherUser.last_seen_at}
-                      />
+                    <LiveStatusAvatar
+                      avatarUrl={otherUser.avatar_url ?? null}
+                      displayName={otherUser.display_name}
+                      size="md"
+                      lastSeenAt={otherUser.last_seen_at}
+                    />
 
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center justify-between gap-2">
-                          <p
-                            className={cn(
-                              "text-sm truncate",
-                              hasUnread ? "font-semibold" : "font-medium",
-                            )}
-                          >
-                            {otherUser.display_name}
-                          </p>
-                          {lastMessage && (
-                            <span className="text-[11px] text-muted-foreground shrink-0">
-                              {formatRelativeTime(lastMessage.created_at)}
-                            </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center justify-between gap-2">
+                        <p
+                          className={cn(
+                            "text-sm truncate",
+                            hasUnread ? "font-semibold" : "font-medium",
                           )}
-                        </div>
-
-                        <div className="flex items-center justify-between gap-2 mt-0.5">
-                          <p
-                            className={cn(
-                              "text-xs truncate",
-                              hasUnread
-                                ? "font-medium text-foreground"
-                                : "text-muted-foreground",
-                            )}
-                          >
-                            {lastMessage
-                              ? lastMessage.message_type === "system"
-                                ? lastMessage.content
-                                : lastMessage.message_type === "video_invite"
-                                  ? lastMessage.sender_id === currentUserId
-                                    ? "You started a video call"
-                                    : "Incoming video call"
-                                  : `${lastMessage.sender_id === currentUserId ? "You: " : ""}${lastMessage.content}`
-                              : "No messages yet"}
-                          </p>
-                          {isPendingCall ? (
-                            <span className="shrink-0 flex items-center gap-1 rounded-full bg-green-500 text-white px-2 py-0.5 text-[10px] font-semibold animate-pulse">
-                              <Video className="size-3" />
-                              Incoming call
-                            </span>
-                          ) : hasUnread ? (
-                            <Badge
-                              variant="destructive"
-                              className="shrink-0 h-4 min-w-4 px-1 text-[10px] flex items-center justify-center"
-                            >
-                              {unreadCount > 99 ? "99+" : unreadCount}
-                            </Badge>
-                          ) : null}
-                        </div>
-                      </div>
-                    </Link>
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger
-                          asChild
-                          onClick={(e) => handleArchive(e, conversation.id)}
                         >
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="size-8 shrink-0"
+                          {otherUser.display_name}
+                        </p>
+                        {lastMessage && (
+                          <span className="text-[11px] text-muted-foreground shrink-0">
+                            {formatRelativeTime(lastMessage.created_at)}
+                          </span>
+                        )}
+                      </div>
+
+                      <div className="flex items-center justify-between gap-2 mt-0.5">
+                        <p
+                          className={cn(
+                            "text-xs truncate",
+                            hasUnread
+                              ? "font-medium text-foreground"
+                              : "text-muted-foreground",
+                          )}
+                        >
+                          {lastMessage
+                            ? lastMessage.message_type === "system"
+                              ? lastMessage.content
+                              : lastMessage.message_type === "video_invite"
+                                ? lastMessage.sender_id === currentUserId
+                                  ? "You started a video call"
+                                  : "Incoming video call"
+                                : `${lastMessage.sender_id === currentUserId ? "You: " : ""}${lastMessage.content}`
+                            : "No messages yet"}
+                        </p>
+                        {isPendingCall && (
+                          <span className="shrink-0 flex items-center gap-1 rounded-full bg-green-500 text-white px-2 py-0.5 text-[10px] font-semibold animate-pulse">
+                            <Video className="size-3" />
+                            Incoming call
+                          </span>
+                        )}
+                        {hasUnread && !isPendingCall && (
+                          <Badge
+                            variant="destructive"
+                            className="shrink-0 h-4 min-w-4 px-1 text-[10px] flex items-center justify-center"
                           >
-                            <Archive className="size-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Archive conversation</TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
-                );
-              },
-            )
+                            {unreadCount > 99 ? "99+" : unreadCount}
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                  </Link>
+
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger
+                        asChild
+                        onClick={(e) => handleArchive(e, conversation.id)}
+                      >
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-8 shrink-0"
+                        >
+                          <Archive className="size-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Archive conversation</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger
+                        asChild
+                        onClick={(e) => handleDelete(e, conversation.id)}
+                      >
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-8 shrink-0"
+                        >
+                          <Trash className="size-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Delete conversation</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </div>
+              );
+            },
+          )
         )}
       </div>
     </div>

--- a/components/messages/ConversationList.tsx
+++ b/components/messages/ConversationList.tsx
@@ -10,7 +10,7 @@ import { getAvatarColor } from "@/lib/utils/avatar";
 import { formatRelativeTime } from "@/lib/utils/time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { UsersRound, Archive, Video, BookMarked } from "lucide-react";
+import { UsersRound, Archive, Video, BookMarked, Trash } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -36,7 +36,10 @@ export function ConversationList({
   const [conversations, setConversations] =
     useState<ConversationWithDetails[]>(initialConversations);
   const prevInitialIdsRef = useRef(
-    initialConversations.map((c) => c.conversation.id).sort().join(",")
+    initialConversations
+      .map((c) => c.conversation.id)
+      .sort()
+      .join(","),
   );
 
   // Sync from server when initialConversations gains new conversations (e.g. after starting a new thread + refresh)
@@ -58,8 +61,8 @@ export function ConversationList({
     const convId = match[1];
     setConversations((prev) =>
       prev.map((c) =>
-        c.conversation.id === convId ? { ...c, unreadCount: 0 } : c
-      )
+        c.conversation.id === convId ? { ...c, unreadCount: 0 } : c,
+      ),
     );
   }, [pathname]);
 
@@ -81,7 +84,7 @@ export function ConversationList({
         },
         () => {
           router.refresh();
-        }
+        },
       )
       .on(
         "postgres_changes",
@@ -91,7 +94,7 @@ export function ConversationList({
 
           setConversations((prev) => {
             const idx = prev.findIndex(
-              (c) => c.conversation.id === newMsg.conversation_id
+              (c) => c.conversation.id === newMsg.conversation_id,
             );
 
             // Unknown conversation — refresh from server as a fallback.
@@ -104,7 +107,8 @@ export function ConversationList({
             const conv = { ...updated[idx] };
             conv.lastMessage = newMsg;
 
-            const isViewing = pathname === `/messages/${newMsg.conversation_id}`;
+            const isViewing =
+              pathname === `/messages/${newMsg.conversation_id}`;
             if (newMsg.sender_id !== currentUserId && !isViewing) {
               conv.unreadCount = (conv.unreadCount ?? 0) + 1;
             }
@@ -112,7 +116,7 @@ export function ConversationList({
             updated.splice(idx, 1);
             return [conv, ...updated];
           });
-        }
+        },
       )
       .subscribe();
 
@@ -130,7 +134,29 @@ export function ConversationList({
       .update({ archived: true })
       .eq("conversation_id", conversationId)
       .eq("user_id", currentUserId);
-    setConversations((prev) => prev.filter((c) => c.conversation.id !== conversationId));
+    setConversations((prev) =>
+      prev.filter((c) => c.conversation.id !== conversationId),
+    );
+    if (pathname === `/messages/${conversationId}`) {
+      router.push("/messages");
+    }
+    router.refresh();
+  }
+
+  async function handleDelete(
+    e: React.MouseEvent<HTMLButtonElement>,
+    conversationId: string,
+  ) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const supabase = createClient();
+    await supabase.from("conversations").delete().eq("id", conversationId);
+
+    setConversations((prev) =>
+      prev.filter((c) => c.conversation.id !== conversationId),
+    );
+
     if (pathname === `/messages/${conversationId}`) {
       router.push("/messages");
     }
@@ -150,14 +176,16 @@ export function ConversationList({
         {/* My Notes — always pinned at top */}
         {(() => {
           const isNotesActive = pathname === `/messages/${selfNotesId}`;
-          const notesConv = conversations.find((c) => c.conversation.id === selfNotesId);
+          const notesConv = conversations.find(
+            (c) => c.conversation.id === selfNotesId,
+          );
           const lastNoteMsg = notesConv?.lastMessage;
           return (
             <Link
               href={`/messages/${selfNotesId}`}
               className={cn(
                 "flex items-center gap-3 border-b px-4 py-3 transition-colors hover:bg-accent",
-                isNotesActive && "bg-accent"
+                isNotesActive && "bg-accent",
               )}
             >
               <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
@@ -180,67 +208,192 @@ export function ConversationList({
           );
         })()}
 
-        {conversations.filter((c) => c.conversation.id !== selfNotesId).length === 0 ? (
+        {conversations.filter((c) => c.conversation.id !== selfNotesId)
+          .length === 0 ? (
           <div className="flex flex-col items-center justify-center h-40 text-center px-6">
-            <p className="text-sm text-muted-foreground">No conversations yet.</p>
+            <p className="text-sm text-muted-foreground">
+              No conversations yet.
+            </p>
             <p className="text-xs text-muted-foreground mt-1">
               Message a member to get started.
             </p>
           </div>
         ) : (
-          conversations.filter((c) => c.conversation.id !== selfNotesId).map(
-            ({ conversation, participants, lastMessage, unreadCount, groupName, groupSlug }) => {
-              const isActive = pathname === `/messages/${conversation.id}`;
-              const hasUnread = unreadCount > 0;
-              const isGroupConv = conversation.type === "group";
+          conversations
+            .filter((c) => c.conversation.id !== selfNotesId)
+            .map(
+              ({
+                conversation,
+                participants,
+                lastMessage,
+                unreadCount,
+                groupName,
+                groupSlug,
+              }) => {
+                const isActive = pathname === `/messages/${conversation.id}`;
+                const hasUnread = unreadCount > 0;
+                const isGroupConv = conversation.type === "group";
 
-              const isPendingCall =
-                lastMessage?.message_type === "video_invite" &&
-                lastMessage.sender_id !== currentUserId;
+                const isPendingCall =
+                  lastMessage?.message_type === "video_invite" &&
+                  lastMessage.sender_id !== currentUserId;
 
-              if (isGroupConv) {
+                if (isGroupConv) {
+                  return (
+                    <div
+                      key={conversation.id}
+                      className={cn(
+                        "flex items-center gap-1 border-b px-4 py-3 transition-colors hover:bg-accent",
+                        isActive && "bg-accent",
+                      )}
+                    >
+                      <Link
+                        href={`/messages/${conversation.id}`}
+                        className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
+                      >
+                        {/* Group icon avatar */}
+                        <div className="relative shrink-0">
+                          <div
+                            className={cn(
+                              "flex size-10 items-center justify-center rounded-full text-white text-sm font-semibold",
+                              getAvatarColor(groupName ?? "Group"),
+                            )}
+                          >
+                            <UsersRound className="size-4" />
+                          </div>
+                        </div>
+
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="flex items-center gap-1.5 min-w-0">
+                              <p
+                                className={cn(
+                                  "text-sm truncate",
+                                  hasUnread ? "font-semibold" : "font-medium",
+                                )}
+                              >
+                                {groupName ?? "Group"}
+                              </p>
+                              <Badge
+                                variant="secondary"
+                                className="shrink-0 text-[10px] px-1.5 py-0 h-4"
+                              >
+                                Group
+                              </Badge>
+                            </div>
+                            {lastMessage && (
+                              <span className="text-[11px] text-muted-foreground shrink-0">
+                                {formatRelativeTime(lastMessage.created_at)}
+                              </span>
+                            )}
+                          </div>
+
+                          <div className="flex items-center justify-between gap-2 mt-0.5">
+                            <p
+                              className={cn(
+                                "text-xs truncate",
+                                hasUnread
+                                  ? "font-medium text-foreground"
+                                  : "text-muted-foreground",
+                              )}
+                            >
+                              {lastMessage
+                                ? lastMessage.message_type === "system"
+                                  ? lastMessage.content
+                                  : lastMessage.message_type === "video_invite"
+                                    ? lastMessage.sender_id === currentUserId
+                                      ? "You started a video call"
+                                      : "Incoming video call"
+                                    : `${lastMessage.sender_id === currentUserId ? "You: " : ""}${lastMessage.content}`
+                                : "No messages yet"}
+                            </p>
+                            {isPendingCall ? (
+                              <span className="shrink-0 flex items-center gap-1 rounded-full bg-green-500 text-white px-2 py-0.5 text-[10px] font-semibold animate-pulse">
+                                <Video className="size-3" />
+                                Incoming call
+                              </span>
+                            ) : hasUnread ? (
+                              <Badge
+                                variant="destructive"
+                                className="shrink-0 h-4 min-w-4 px-1 text-[10px] flex items-center justify-center"
+                              >
+                                {unreadCount > 99 ? "99+" : unreadCount}
+                              </Badge>
+                            ) : null}
+                          </div>
+                        </div>
+                      </Link>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger
+                            asChild
+                            onClick={(e) => handleArchive(e, conversation.id)}
+                          >
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-8 shrink-0"
+                            >
+                              <Archive className="size-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Archive conversation</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger
+                            asChild
+                            onClick={(e) => handleDelete(e, conversation.id)}
+                          >
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-8 shrink-0"
+                            >
+                              <Trash className="size-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Delete conversation</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+                  );
+                }
+
+                // DM row
+                const otherUser = participants[0];
+                if (!otherUser) return null;
+
                 return (
                   <div
                     key={conversation.id}
                     className={cn(
                       "flex items-center gap-1 border-b px-4 py-3 transition-colors hover:bg-accent",
-                      isActive && "bg-accent"
+                      isActive && "bg-accent",
                     )}
                   >
                     <Link
                       href={`/messages/${conversation.id}`}
                       className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
                     >
-                      {/* Group icon avatar */}
-                      <div className="relative shrink-0">
-                        <div
-                          className={cn(
-                            "flex size-10 items-center justify-center rounded-full text-white text-sm font-semibold",
-                            getAvatarColor(groupName ?? "Group")
-                          )}
-                        >
-                          <UsersRound className="size-4" />
-                        </div>
-                      </div>
+                      <LiveStatusAvatar
+                        avatarUrl={otherUser.avatar_url ?? null}
+                        displayName={otherUser.display_name}
+                        size="md"
+                        lastSeenAt={otherUser.last_seen_at}
+                      />
 
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center justify-between gap-2">
-                          <div className="flex items-center gap-1.5 min-w-0">
-                            <p
-                              className={cn(
-                                "text-sm truncate",
-                                hasUnread ? "font-semibold" : "font-medium"
-                              )}
-                            >
-                              {groupName ?? "Group"}
-                            </p>
-                            <Badge
-                              variant="secondary"
-                              className="shrink-0 text-[10px] px-1.5 py-0 h-4"
-                            >
-                              Group
-                            </Badge>
-                          </div>
+                          <p
+                            className={cn(
+                              "text-sm truncate",
+                              hasUnread ? "font-semibold" : "font-medium",
+                            )}
+                          >
+                            {otherUser.display_name}
+                          </p>
                           {lastMessage && (
                             <span className="text-[11px] text-muted-foreground shrink-0">
                               {formatRelativeTime(lastMessage.created_at)}
@@ -254,7 +407,7 @@ export function ConversationList({
                               "text-xs truncate",
                               hasUnread
                                 ? "font-medium text-foreground"
-                                : "text-muted-foreground"
+                                : "text-muted-foreground",
                             )}
                           >
                             {lastMessage
@@ -285,12 +438,14 @@ export function ConversationList({
                     </Link>
                     <TooltipProvider>
                       <Tooltip>
-                        <TooltipTrigger asChild>
+                        <TooltipTrigger
+                          asChild
+                          onClick={(e) => handleArchive(e, conversation.id)}
+                        >
                           <Button
                             variant="ghost"
                             size="icon"
                             className="size-8 shrink-0"
-                            onClick={(e) => handleArchive(e, conversation.id)}
                           >
                             <Archive className="size-4" />
                           </Button>
@@ -300,102 +455,8 @@ export function ConversationList({
                     </TooltipProvider>
                   </div>
                 );
-              }
-
-              // DM row
-              const otherUser = participants[0];
-              if (!otherUser) return null;
-
-              return (
-                <div
-                  key={conversation.id}
-                  className={cn(
-                    "flex items-center gap-1 border-b px-4 py-3 transition-colors hover:bg-accent",
-                    isActive && "bg-accent"
-                  )}
-                >
-                  <Link
-                    href={`/messages/${conversation.id}`}
-                    className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
-                  >
-                    <LiveStatusAvatar
-                      avatarUrl={otherUser.avatar_url ?? null}
-                      displayName={otherUser.display_name}
-                      size="md"
-                      lastSeenAt={otherUser.last_seen_at}
-                    />
-
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center justify-between gap-2">
-                        <p
-                          className={cn(
-                            "text-sm truncate",
-                            hasUnread ? "font-semibold" : "font-medium"
-                          )}
-                        >
-                          {otherUser.display_name}
-                        </p>
-                        {lastMessage && (
-                          <span className="text-[11px] text-muted-foreground shrink-0">
-                            {formatRelativeTime(lastMessage.created_at)}
-                          </span>
-                        )}
-                      </div>
-
-                      <div className="flex items-center justify-between gap-2 mt-0.5">
-                        <p
-                          className={cn(
-                            "text-xs truncate",
-                            hasUnread
-                              ? "font-medium text-foreground"
-                              : "text-muted-foreground"
-                          )}
-                        >
-                          {lastMessage
-                            ? lastMessage.message_type === "system"
-                              ? lastMessage.content
-                              : lastMessage.message_type === "video_invite"
-                                ? lastMessage.sender_id === currentUserId
-                                  ? "You started a video call"
-                                  : "Incoming video call"
-                                : `${lastMessage.sender_id === currentUserId ? "You: " : ""}${lastMessage.content}`
-                            : "No messages yet"}
-                        </p>
-                        {isPendingCall ? (
-                          <span className="shrink-0 flex items-center gap-1 rounded-full bg-green-500 text-white px-2 py-0.5 text-[10px] font-semibold animate-pulse">
-                            <Video className="size-3" />
-                            Incoming call
-                          </span>
-                        ) : hasUnread ? (
-                          <Badge
-                            variant="destructive"
-                            className="shrink-0 h-4 min-w-4 px-1 text-[10px] flex items-center justify-center"
-                          >
-                            {unreadCount > 99 ? "99+" : unreadCount}
-                          </Badge>
-                        ) : null}
-                      </div>
-                    </div>
-                  </Link>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="size-8 shrink-0"
-                          onClick={(e) => handleArchive(e, conversation.id)}
-                        >
-                          <Archive className="size-4" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Archive conversation</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              );
-            }
-          )
+              },
+            )
         )}
       </div>
     </div>

--- a/components/messages/ConversationList.tsx
+++ b/components/messages/ConversationList.tsx
@@ -41,7 +41,6 @@ export function ConversationList({
       .join(","),
   );
 
-  // Sync from server when initialConversations gains new conversations
   useEffect(() => {
     const ids = initialConversations
       .map((c) => c.conversation.id)
@@ -53,7 +52,6 @@ export function ConversationList({
     }
   }, [initialConversations]);
 
-  // Reset unread count when a conversation becomes active
   useEffect(() => {
     const match = pathname.match(/\/messages\/([^/]+)/);
     if (!match) return;
@@ -65,7 +63,6 @@ export function ConversationList({
     );
   }, [pathname]);
 
-  // Subscribe to new messages for real-time updates
   useEffect(() => {
     const supabase = createClient();
 
@@ -166,22 +163,18 @@ export function ConversationList({
     router.refresh();
   }
 
-  // Only show DMs + notes
   const dmConversations = conversations.filter(
     (c) => c.conversation.id !== selfNotesId && c.conversation.type !== "group",
   );
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
       <div className="flex items-center justify-between border-b px-4 py-3 shrink-0">
         <h2 className="text-base font-semibold">Messages</h2>
         <NewMessageDialog />
       </div>
 
-      {/* List */}
       <div className="flex-1 overflow-y-auto">
-        {/* My Notes */}
         {(() => {
           const isNotesActive = pathname === `/messages/${selfNotesId}`;
           const notesConv = conversations.find(

--- a/components/messages/MessageInput.tsx
+++ b/components/messages/MessageInput.tsx
@@ -3,7 +3,7 @@
 import { useRef, useEffect, useState } from "react";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { SendHorizonal, Paperclip } from "lucide-react";
+import { SendHorizontal, Paperclip } from "lucide-react";
 import { FileAttachmentPreview } from "./FileAttachmentPreview";
 
 const ATTACHMENT_ACCEPT =
@@ -30,8 +30,11 @@ export function MessageInput({
 }: MessageInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [internalAttachment, setInternalAttachment] = useState<File | null>(null);
+  const [internalAttachment, setInternalAttachment] = useState<File | null>(
+    null,
+  );
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
 
   const attachment = controlledAttachment ?? internalAttachment;
   const setAttachment = onAttachmentChange ?? setInternalAttachment;
@@ -43,20 +46,36 @@ export function MessageInput({
     ta.style.height = `${Math.min(ta.scrollHeight, 104)}px`;
   }, [value]);
 
+  async function send() {
+    if (sending) return;
+    if (!value.trim() && !attachment) return;
+    if (disabled) return;
+
+    setSending(true);
+
+    try {
+      console.log("SEND CALLED"); // temp debug
+
+      await onSend(value.trim(), attachment ?? undefined);
+
+      // clear AFTER send
+      setAttachment(null);
+      setAttachmentError(null);
+      onChange("");
+    } finally {
+      setSending(false);
+    }
+  }
+
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      const canSend = (value.trim() || attachment) && !disabled;
-      if (canSend) onSend(value.trim(), attachment ?? undefined);
+      send();
     }
   }
 
   function handleSendClick() {
-    if (!value.trim() && !attachment) return;
-    if (disabled) return;
-    onSend(value.trim(), attachment ?? undefined);
-    setAttachment(null);
-    setAttachmentError(null);
+    send();
   }
 
   function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
@@ -118,11 +137,11 @@ export function MessageInput({
         <Button
           size="icon"
           onClick={handleSendClick}
-          disabled={disabled || (!value.trim() && !attachment)}
+          disabled={disabled || sending || (!value.trim() && !attachment)}
           className="shrink-0"
           aria-label="Send message"
         >
-          <SendHorizonal className="size-4" />
+          <SendHorizontal className="size-4" />
         </Button>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
         "next": "16.1.6",
         "nodemailer": "^8.0.1",
         "radix-ui": "^1.4.3",
-        "react": "19.2.3",
+        "react": "^19.2.3",
         "react-day-picker": "^9.14.0",
-        "react-dom": "19.2.3",
+        "react-dom": "^19.2.3",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0"
@@ -37,8 +37,8 @@
         "@types/jest": "^29.5.12",
         "@types/node": "^20",
         "@types/nodemailer": "^7.0.11",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "jest": "^29.7.0",
@@ -47,7 +47,7 @@
         "supabase": "^2.76.15",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5201,9 +5201,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
-      "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "next": "16.1.6",
     "nodemailer": "^8.0.1",
     "radix-ui": "^1.4.3",
-    "react": "19.2.3",
+    "react": "^19.2.3",
     "react-day-picker": "^9.14.0",
-    "react-dom": "19.2.3",
+    "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"
@@ -41,8 +41,8 @@
     "@types/jest": "^29.5.12",
     "@types/node": "^20",
     "@types/nodemailer": "^7.0.11",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "jest": "^29.7.0",
@@ -51,6 +51,6 @@
     "supabase": "^2.76.15",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5.9.3"
   }
 }

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+// test change


### PR DESCRIPTION
Removed Group Chats from ConversationsList so they could not be deleted entirely by a single participant, added delete function and button with trash icon, corrected incorrect icon spelling sendHorizonal to sendHorizontal from MessageInput.tsx

MockConversationList component created for testing ConversationList.
Includes DM, group conversations, with proper typing fixes for Message.metadata and Conversation fields.

Run `npm run dev` and navigate to `/ConversationList_test/page` to see the mocked ConversationList.
Group conversations are included but filtered out in the component.

Resolves inability to delete conversations, prevents group chat from being affected or cluttering up DMs, adds the trash icon next to the archive button on CoversationList.

Next steps are to display archived messages, ensure double loading messages have a sending state, and group chats can be put in separate panel later

Closes #123
Group conversations are accessible still through groups