### PR TITLE
Return to no ESLint errors and warnings

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,9 +26,8 @@ jobs:
 
       - run: npm ci
 
-      # Temp: disable linting on every pr for now
-      #- name: Lint
-      #  run: npm run lint
+      - name: Lint
+        run: npm run lint
 
       - name: Install Vercel CLI
         run: npm install -g vercel@latest

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,9 +26,8 @@ jobs:
 
       - run: npm ci
       
-      # Temp: disable linting on every pr for now
-      #- name: Lint
-      #  run: npm run lint
+      - name: Lint
+        run: npm run lint
 
       - name: Install Vercel CLI
         run: npm install -g vercel@latest

--- a/app/(app)/events/page.tsx
+++ b/app/(app)/events/page.tsx
@@ -97,11 +97,11 @@ export default async function EventsPage({
   const past = pastRaw as EventRow[];
 
   const eventIds = upcoming.map((e) => e.id);
-  let rsvpCountsMap: Record<
+  const rsvpCountsMap: Record<
     string,
     { going: number; maybe: number; declined: number }
   > = {};
-  let userRsvpMap: Record<string, { status: string }> = {};
+  const userRsvpMap: Record<string, { status: string }> = {};
 
   if (eventIds.length > 0) {
     const { data: rsvps } = await supabase

--- a/app/(app)/groups/[slug]/page.tsx
+++ b/app/(app)/groups/[slug]/page.tsx
@@ -157,8 +157,8 @@ export default async function GroupHubPage({ params }: Props) {
   }
 
   let upcomingEvents: Awaited<ReturnType<typeof fetchUpcomingEvents>> = [];
-  let eventRsvpCounts: Record<string, { going: number; maybe: number; declined: number }> = {};
-  let eventUserRsvp: Record<string, { status: string }> = {};
+  const eventRsvpCounts: Record<string, { going: number; maybe: number; declined: number }> = {};
+  const eventUserRsvp: Record<string, { status: string }> = {};
   try {
     upcomingEvents = await fetchUpcomingEvents({ groupId: group.id });
     if (upcomingEvents.length > 0) {

--- a/app/(app)/jobs/EditJobForm.tsx
+++ b/app/(app)/jobs/EditJobForm.tsx
@@ -72,7 +72,7 @@ export function EditJobForm({ job }: Props) {
   function toggleRole(role: JobRole) {
     setSelectedRoles((prev) => {
       const next = new Set(prev);
-      next.has(role) ? next.delete(role) : next.add(role);
+      if (next.has(role)) next.delete(role); else next.add(role);
       return next;
     });
   }

--- a/app/(app)/jobs/PostJobForm.tsx
+++ b/app/(app)/jobs/PostJobForm.tsx
@@ -67,7 +67,7 @@ export function PostJobForm() {
   function toggleRole(role: JobRole) {
     setSelectedRoles((prev) => {
       const next = new Set(prev);
-      next.has(role) ? next.delete(role) : next.add(role);
+      if (next.has(role)) next.delete(role); else next.add(role);
       return next;
     });
   }

--- a/app/(app)/jobs/WishlistButton.tsx
+++ b/app/(app)/jobs/WishlistButton.tsx
@@ -21,6 +21,7 @@ export function WishlistButton({ jobPostingId, company, position, url, initialWi
 
   // Sync with server state when job or initialWishlisted changes (e.g. after refresh or switching jobs)
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setWishlisted(initialWishlisted);
   }, [jobPostingId, initialWishlisted]);
 

--- a/app/(app)/learning/LearningClient.tsx
+++ b/app/(app)/learning/LearningClient.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import {
   Star, ChevronDown, ChevronRight, Trash2, Plus, ExternalLink,
   Loader2, GraduationCap, PlaySquare, BookOpen, Route, BookMarked,
-  ListTodo, Users2, X, ArrowUpRight,
+  Users2, X, ArrowUpRight,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,7 +30,6 @@ import {
 } from "./learning-tracker-actions";
 import type { LearningPath, LearningPathItem, LearningResource, ResourceType } from "./types";
 import type { StudyGroupRow } from "./page";
-import type { TrackerItem } from "./page";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -570,7 +569,7 @@ function PathsTab({ paths, itemsByPath, currentUserId, isPlatformAdmin, studyGro
   const toggle = (id: string) =>
     setExpandedIds((prev) => {
       const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
+      if (next.has(id)) next.delete(id); else next.add(id);
       return next;
     });
 

--- a/app/(app)/projects/AddProjectForm.tsx
+++ b/app/(app)/projects/AddProjectForm.tsx
@@ -70,7 +70,7 @@ export function AddProjectForm() {
   function toggleRole(value: string) {
     setRolesSelected((prev) => {
       const next = new Set(prev);
-      next.has(value) ? next.delete(value) : next.add(value);
+      if (next.has(value)) next.delete(value); else next.add(value);
       return next;
     });
   }

--- a/app/(app)/projects/ProjectsClient.tsx
+++ b/app/(app)/projects/ProjectsClient.tsx
@@ -47,7 +47,7 @@ export function ProjectsClient({ projects, currentUserId, isPlatformAdmin }: Pro
   function toggleMentorship(f: MentorshipFilter) {
     setMentorshipFilters((prev) => {
       const next = new Set(prev);
-      next.has(f) ? next.delete(f) : next.add(f);
+      if (next.has(f)) next.delete(f); else next.add(f);
       return next;
     });
   }

--- a/app/(app)/tracker/ApplicationDetailModal.tsx
+++ b/app/(app)/tracker/ApplicationDetailModal.tsx
@@ -615,7 +615,6 @@ export function ApplicationDetailModal({ app, open, onClose, currentUserId, inte
                       <div className="space-y-1.5">
                         <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Past</p>
                         {pastIvs.map((iv) => {
-                          const isToday = iv.interview_date === todayStr;
                           return (
                             <div key={iv.id} className="flex items-start justify-between gap-2 rounded-lg px-3 py-2.5 bg-muted/20">
                               <div className="min-w-0">

--- a/app/(app)/tracker/ApplicationForm.tsx
+++ b/app/(app)/tracker/ApplicationForm.tsx
@@ -12,7 +12,7 @@ import {
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
 } from "@/components/ui/dialog";
-import { Plus, Loader2, Pencil } from "lucide-react";
+import { Plus, Loader2 } from "lucide-react";
 import { createApplication, updateApplication, type ApplicationStatus, type JobApplicationInput } from "./actions";
 import { STATUSES } from "./constants";
 

--- a/app/(app)/tracker/TrackerClient.tsx
+++ b/app/(app)/tracker/TrackerClient.tsx
@@ -271,7 +271,7 @@ function CommunityNotesSection({ notes = [] }: { notes?: CommunityNote[] }) {
           </h2>
         </div>
         <p className="text-sm text-muted-foreground rounded-lg border border-dashed p-5 text-center">
-          No community notes yet for the companies you've applied to.
+          No community notes yet for the companies you&apos;ve applied to.
         </p>
       </section>
     );

--- a/app/admin/approvals/actions.ts
+++ b/app/admin/approvals/actions.ts
@@ -31,7 +31,7 @@ async function ensureAdmin(): Promise<boolean> {
   return true;
 }
 
-export async function approveUser(userId: string, _formData?: FormData): Promise<void> {
+export async function approveUser(userId: string): Promise<void> {
   if (!(await ensureAdmin())) return;
 
   // Use service role to bypass RLS — admins updating other users' rows
@@ -56,7 +56,7 @@ export async function approveUser(userId: string, _formData?: FormData): Promise
   redirect("/admin/approvals");
 }
 
-export async function rejectUser(userId: string, _formData?: FormData): Promise<void> {
+export async function rejectUser(userId: string): Promise<void> {
   if (!(await ensureAdmin())) return;
 
   const serviceClient = createServiceClient();

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -108,9 +108,9 @@ function ComingSoon({ article }: { article: { title: string; excerpt: string } }
       </p>
       <p className="mt-8 text-sm text-muted-foreground">
         Full text coming soon. Check back or{" "}
-        <a href="/#newsletter" className="font-medium text-primary-orange underline underline-offset-2 hover:text-primary-orange-hover">
+        <Link href="/#newsletter" className="font-medium text-primary-orange underline underline-offset-2 hover:text-primary-orange-hover">
           subscribe to our newsletter
-        </a>{" "}
+        </Link>{" "}
         to be notified.
       </p>
     </div>

--- a/app/programs/no-robo-bosses/page.tsx
+++ b/app/programs/no-robo-bosses/page.tsx
@@ -47,7 +47,7 @@ export default async function NoRoboBossesPage() {
                 no restrictions on how employers use AI to fire, discipline,
                 or lay off workers
               </strong>{" "}
-              in California. The No Robo Bosses Act changes that, and we're
+              in California. The No Robo Bosses Act changes that, and we&apos;re
               fighting to make it law.
             </p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -83,21 +83,21 @@ export default async function NoRoboBossesPage() {
               The Crisis
             </p>
             <h2 className="font-bebas text-4xl text-dark-blue sm:text-5xl">
-              Machines don't get to end your livelihood.
+              Machines don&apos;t get to end your livelihood.
             </h2>
             <p className="mt-5 text-base leading-relaxed text-foreground/80 sm:text-lg">
               Every month, more employers are using AI to automate, erode, and
               eliminate jobs without oversight, accountability, or the
-              requirement to tell workers or the public what's happening.
+              requirement to tell workers or the public what&apos;s happening.
               Companies like Amazon, Salesforce, and Dow Chemical have
               announced mass layoffs and hiring freezes driven by AI investment,
               while workers bear all the costs and share none of the gains.
             </p>
             <blockquote className="mt-8 border-l-4 border-primary-orange pl-5">
               <p className="text-lg font-medium italic leading-relaxed text-dark-blue">
-                "Employers are devastating workers&apos; livelihoods and taking
+                &quot;Employers are devastating workers&apos; livelihoods and taking
                 no responsibility for the callous decisions of this unchecked
-                technology. This is unacceptable."
+                technology. This is unacceptable.&quot;
               </p>
               <cite className="mt-3 block text-sm font-semibold text-muted-foreground not-italic">
                 — Lorena Gonzalez, President, California Federation of Labor
@@ -279,7 +279,7 @@ export default async function NoRoboBossesPage() {
             <p className="mt-4 max-w-3xl text-base leading-relaxed text-muted-foreground">
               As companies work to rapidly deploy AI agents across the economy, we need
               legislation to ensure these systems remain transparent and that workers
-              don't bear the burden.
+              don&apos;t bear the burden.
             </p>
             <div className="mt-6 grid gap-6 sm:grid-cols-3">
               {[
@@ -326,7 +326,7 @@ export default async function NoRoboBossesPage() {
               Workers cannot go another year unprotected.
             </h2>
             <p className="mt-4 max-w-3xl text-base leading-relaxed text-white/80 sm:text-lg">
-              Passing these bills will require workers to organize, contact their legislators, and share their stories. Here's where to start.
+              Passing these bills will require workers to organize, contact their legislators, and share their stories. Here&apos;s where to start.
             </p>
 
             <div className="mt-8 grid gap-4 sm:grid-cols-3">

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Users, CalendarDays, BookOpen, Mail, Megaphone, ArrowRight } from "lucide-react";
+import { BookOpen, Mail, Megaphone, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   BlueSkyIcon,

--- a/components/about/about-advisory-board.tsx
+++ b/components/about/about-advisory-board.tsx
@@ -1,5 +1,3 @@
-import { User } from "lucide-react";
-
 const ADVISORY_BOARD = [
   {
     name: "Andrew Stettner",

--- a/components/about/about-organization.tsx
+++ b/components/about/about-organization.tsx
@@ -16,12 +16,12 @@ export function AboutOrganization() {
           </p>
           <p className="text-base leading-relaxed sm:text-lg">
             Software engineers, call center workers, and copywriters are among the first to experience a significant shift in the capacity of AI to replace tasks we once performed.
-            For decades, "Teach X to Code" was promoted as an economic justice strategy for marginalized workers, from coal miners to the formerly incarcerated. Now these workers
+            For decades, &quot;Teach X to Code&quot; was promoted as an economic justice strategy for marginalized workers, from coal miners to the formerly incarcerated. Now these workers
             from nontraditional training paths are among the first to be laid off.
           </p>
           <p className="text-base leading-relaxed sm:text-lg">
           Knowledge workers are experiencing what manufacturing and agricultural workers faced decades ago, with few institutional supports to navigate this time of transition. <strong>We believe that no worker should have to bear the costs of automation alone.</strong> The worst predicted harms of A.I. are not inevitable, but we
-          can't afford to wait for mass unemployment before we mobilize. This moment presents a narrow window of opportunity to intervene by building worker power, strengthening social safety nets, and organizing for broader legal, institutional, and cultural change.
+          can&apos;t afford to wait for mass unemployment before we mobilize. This moment presents a narrow window of opportunity to intervene by building worker power, strengthening social safety nets, and organizing for broader legal, institutional, and cultural change.
           </p>
         </div>
       </div>

--- a/components/about/about-team.tsx
+++ b/components/about/about-team.tsx
@@ -1,5 +1,4 @@
 import Image from "next/image";
-import { User } from "lucide-react";
 
 type TeamMember = {
   name: string;

--- a/components/dashboard/ActiveChatsCard.tsx
+++ b/components/dashboard/ActiveChatsCard.tsx
@@ -57,7 +57,6 @@ export async function ActiveChatsCard({ userId }: ActiveChatsCardProps) {
                 lastMessage,
                 unreadCount,
                 groupName,
-                groupSlug,
               }) => {
                 const isGroup = conversation.type === "group";
                 const name = isGroup ? groupName ?? "Group" : participants[0]?.display_name ?? "Unknown";

--- a/components/dashboard/MyGroupsCard.tsx
+++ b/components/dashboard/MyGroupsCard.tsx
@@ -41,7 +41,7 @@ export async function MyGroupsCard({ userId }: MyGroupsCardProps) {
     .map((r) => (r as { group_id: string }).group_id)
     .filter(Boolean);
 
-  let memberCounts: Record<string, number> = {};
+  const memberCounts: Record<string, number> = {};
   if (groupIds.length > 0) {
     const { data: counts } = await supabase
       .from("group_members")
@@ -61,7 +61,7 @@ export async function MyGroupsCard({ userId }: MyGroupsCardProps) {
     })
     .filter((id): id is string => Boolean(id));
 
-  let unreadByConvId: Record<string, number> = {};
+  const unreadByConvId: Record<string, number> = {};
   if (conversationIds.length > 0) {
     const { data: participations } = await supabase
       .from("conversation_participants")

--- a/components/dashboard/PollsCard.tsx
+++ b/components/dashboard/PollsCard.tsx
@@ -28,8 +28,11 @@ export function PollsCard({ userId, initialPoll }: PollsCardProps) {
 
   // Sync from server when initialPoll changes (e.g. after router.refresh())
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPoll(initialPoll);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelectedOptions(initialPoll?.userVotes ?? []);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setVoted((initialPoll?.userVotes?.length ?? 0) > 0);
   }, [initialPoll?.id, initialPoll?.totalVotes, initialPoll?.userVotes?.length]);
 

--- a/components/dashboard/PollsCard.tsx
+++ b/components/dashboard/PollsCard.tsx
@@ -7,7 +7,6 @@ import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/componen
 import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Checkbox } from "@/components/ui/checkbox";
-import { UserAvatar } from "@/components/shared/UserAvatar";
 import { BarChart3 } from "lucide-react";
 import { CreatePollDialog } from "./CreatePollDialog";
 import type { PollWithDetails } from "@/lib/types";
@@ -28,12 +27,10 @@ export function PollsCard({ userId, initialPoll }: PollsCardProps) {
 
   // Sync from server when initialPoll changes (e.g. after router.refresh())
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPoll(initialPoll);
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelectedOptions(initialPoll?.userVotes ?? []);
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setVoted((initialPoll?.userVotes?.length ?? 0) > 0);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialPoll?.id, initialPoll?.totalVotes, initialPoll?.userVotes?.length]);
 
   const hasSelection = selectedOptions.length > 0;

--- a/components/dashboard/UpcomingEventsCard.tsx
+++ b/components/dashboard/UpcomingEventsCard.tsx
@@ -5,7 +5,6 @@ import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/componen
 import { Button } from "@/components/ui/button";
 import { Calendar, Plus } from "lucide-react";
 import { fetchUpcomingEvents } from "@/lib/events";
-import { eventTypeConfig } from "@/lib/utils/events";
 
 export async function UpcomingEventsCard() {
   const supabase = await createClient();
@@ -74,8 +73,6 @@ export async function UpcomingEventsCard() {
               const isLive =
                 startsAt <= now &&
                 now <= new Date((event as { ends_at: string }).ends_at);
-              const typeConfig =
-                eventTypeConfig[e.event_type] ?? eventTypeConfig.other;
               const dotClass =
                 isLive
                   ? "bg-red-500"

--- a/components/dashboard/UpcomingEventsCard.tsx
+++ b/components/dashboard/UpcomingEventsCard.tsx
@@ -21,7 +21,7 @@ export async function UpcomingEventsCard() {
   const now = new Date();
   const viewerTimezone = viewerProfileResult.data?.timezone ?? "America/Chicago";
 
-  let goingByEventId: Record<string, number> = {};
+  const goingByEventId: Record<string, number> = {};
   if (events.length > 0) {
     const eventIds = events.map((e) => (e as { id: string }).id);
     const { data: rsvps } = await supabase

--- a/components/events/EventCalendarView.tsx
+++ b/components/events/EventCalendarView.tsx
@@ -14,7 +14,6 @@ import {
 } from "date-fns";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { eventTypeConfig } from "@/lib/utils/events";
 import { formatInTimeZone } from "@/lib/utils/timezone";
 import { cn } from "@/lib/utils";
 

--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -44,7 +44,6 @@ export function EventCard({
   event,
   rsvpCounts,
   currentUserRsvp,
-  currentUserId,
   viewerTimezone,
 }: EventCardProps) {
   const [status, setStatus] = useState<"going" | "maybe" | "declined" | null>(

--- a/components/events/EventTimeDisplay.tsx
+++ b/components/events/EventTimeDisplay.tsx
@@ -21,6 +21,7 @@ export function EventTimeDisplay({
 }: EventTimeDisplayProps) {
   const [browserTz, setBrowserTz] = useState<string | null>(null);
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setBrowserTz(Intl.DateTimeFormat().resolvedOptions().timeZone);
   }, []);
 

--- a/components/groups/GroupMemberList.tsx
+++ b/components/groups/GroupMemberList.tsx
@@ -8,7 +8,6 @@ import {
   Crown,
   UserMinus,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { LiveStatusAvatar } from "@/components/shared/LiveStatusAvatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/components/groups/InviteMemberDialog.tsx
+++ b/components/groups/InviteMemberDialog.tsx
@@ -41,11 +41,8 @@ export function InviteMemberDialog({
     if (!open) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setQuery("");
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setResults([]);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setInvited(new Set());
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setError(null);
     }
   }, [open]);

--- a/components/groups/InviteMemberDialog.tsx
+++ b/components/groups/InviteMemberDialog.tsx
@@ -39,9 +39,13 @@ export function InviteMemberDialog({
 
   useEffect(() => {
     if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setQuery("");
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setResults([]);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setInvited(new Set());
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setError(null);
     }
   }, [open]);
@@ -49,6 +53,7 @@ export function InviteMemberDialog({
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (!query.trim()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setResults([]);
       return;
     }

--- a/components/landing/action-network-form-embed.tsx
+++ b/components/landing/action-network-form-embed.tsx
@@ -66,7 +66,7 @@ export function ActionNetworkFormEmbed() {
       setFirstName("");
       setLastName("");
       setZipCode("");
-    } catch (_err) {
+    } catch {
       setError(
         "We couldn't reach the server. Please check your connection and try again.",
       );

--- a/components/landing/landing-future-we-demand.tsx
+++ b/components/landing/landing-future-we-demand.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
-import { useState } from "react";
 
 export function LandingFutureWeDemand() {
 

--- a/components/landing/landing-join-community.tsx
+++ b/components/landing/landing-join-community.tsx
@@ -1,7 +1,6 @@
-import type { User } from "@supabase/supabase-js";
 import { ActionNetworkFormEmbed } from "./action-network-form-embed";
 
-export function LandingJoinCommunity({ user: _user }: { user?: User | null }) {
+export function LandingJoinCommunity() {
   return (
     <section id="newsletter" className="scroll-mt-20 bg-muted px-4 py-16 md:py-24">
       <div className="mx-auto max-w-3xl">

--- a/components/landing/landing-mutual-aid.tsx
+++ b/components/landing/landing-mutual-aid.tsx
@@ -1,6 +1,3 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-
 export function LandingMutualAid() {
   return (
     <section className="bg-primary-orange px-4 py-10 text-white md:py-12">

--- a/components/landing/landing-nav.tsx
+++ b/components/landing/landing-nav.tsx
@@ -22,6 +22,7 @@ export function LandingNav({ user }: { user?: User | null }) {
 
   // After hydration, update to the actual client origin (handles dev + preview URLs)
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSiteUrl(getSiteUrl());
   }, []);
 

--- a/components/landing/landing-our-mission.tsx
+++ b/components/landing/landing-our-mission.tsx
@@ -15,7 +15,7 @@ export function OurMission() {
             </h3>
             <p className="mt-2 text-sm leading-relaxed text-white/95 sm:text-base">
               We organize to advance &quot;Human-First&quot; AI practices
-              to empower workers' voices in decision-making, strengthen our social safety net, and fight for bold policies that ensure equitable access to quality jobs, and a dignified future of
+              to empower workers&apos; voices in decision-making, strengthen our social safety net, and fight for bold policies that ensure equitable access to quality jobs, and a dignified future of
               shared prosperity.
             </p>
           </div>

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -22,7 +22,7 @@ export function LandingPage({ user }: { user?: User | null }) {
         <LandingMutualAid />
         <LandingFutureWeDemand />
         <LandingDonate />
-        <LandingJoinCommunity user={user} />
+        <LandingJoinCommunity />
       </main>
       <LandingFooter />
     </div>

--- a/components/members/MemberCard.tsx
+++ b/components/members/MemberCard.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/card";
 import { LiveStatusAvatar } from "@/components/shared/LiveStatusAvatar";
 import type { Profile } from "@/lib/types";
-import { cn } from "@/lib/utils";
 
 function isNewMember(createdAt: string): boolean {
   const created = new Date(createdAt).getTime();

--- a/components/members/MemberFilters.tsx
+++ b/components/members/MemberFilters.tsx
@@ -32,7 +32,9 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
   // Sync local state when URL changes (e.g. browser back/forward)
   useEffect(() => {
     const q = searchParams.get("q") ?? "";
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSearchInput(q);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDebouncedSearch(q);
   }, [searchParams]);
 

--- a/components/members/MemberFilters.tsx
+++ b/components/members/MemberFilters.tsx
@@ -34,7 +34,6 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
     const q = searchParams.get("q") ?? "";
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setSearchInput(q);
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDebouncedSearch(q);
   }, [searchParams]);
 

--- a/components/messages/ConversationList.tsx
+++ b/components/messages/ConversationList.tsx
@@ -191,7 +191,7 @@ export function ConversationList({
           </div>
         ) : (
           conversations.filter((c) => c.conversation.id !== selfNotesId).map(
-            ({ conversation, participants, lastMessage, unreadCount, groupName, groupSlug }) => {
+            ({ conversation, participants, lastMessage, unreadCount, groupName }) => {
               const isActive = pathname === `/messages/${conversation.id}`;
               const hasUnread = unreadCount > 0;
               const isGroupConv = conversation.type === "group";

--- a/components/messages/ConversationList.tsx
+++ b/components/messages/ConversationList.tsx
@@ -47,6 +47,7 @@ export function ConversationList({
       .join(",");
     if (prevInitialIdsRef.current !== ids) {
       prevInitialIdsRef.current = ids;
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setConversations(initialConversations);
     }
   }, [initialConversations]);
@@ -56,6 +57,7 @@ export function ConversationList({
     const match = pathname.match(/\/messages\/([^/]+)/);
     if (!match) return;
     const convId = match[1];
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setConversations((prev) =>
       prev.map((c) =>
         c.conversation.id === convId ? { ...c, unreadCount: 0 } : c

--- a/components/messages/ConversationView.tsx
+++ b/components/messages/ConversationView.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
 import { UserAvatar } from "@/components/shared/UserAvatar";
-import { getAvatarColor, getInitials } from "@/lib/utils/avatar";
+import { getAvatarColor } from "@/lib/utils/avatar";
 import { getOnlineStatus } from "@/lib/utils/status";
 import { Button } from "@/components/ui/button";
 import {
@@ -135,6 +135,7 @@ export function ConversationView({
     const interval = setInterval(fetchLastSeen, 30_000); // every 30s
     fetchLastSeen(); // run once immediately
     return () => clearInterval(interval);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [otherUser?.id]);
 
   // Open video modal when landing with ?videoRoom= (e.g. from "Join call" in list)

--- a/components/messages/FileAttachmentPreview.tsx
+++ b/components/messages/FileAttachmentPreview.tsx
@@ -35,6 +35,7 @@ export function FileAttachmentPreview({
     >
       {isImage ? (
         <div className="relative size-12 shrink-0 overflow-hidden rounded bg-muted">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={URL.createObjectURL(file)}
             alt=""

--- a/components/messages/MessageBubble.tsx
+++ b/components/messages/MessageBubble.tsx
@@ -3,7 +3,6 @@ import { Video, FileText } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/utils/time";
 import { UserAvatar } from "@/components/shared/UserAvatar";
-import { getAvatarColor, getInitials } from "@/lib/utils/avatar";
 import { getSignedUrl } from "@/lib/storage";
 import { Button } from "@/components/ui/button";
 import type { MessageWithSender } from "@/lib/types";
@@ -24,7 +23,6 @@ function FileMessageBubble({
   storagePath,
   fileName,
   fileSize,
-  fileType,
   isImage,
 }: {
   isOwn: boolean;
@@ -101,6 +99,7 @@ function FileMessageBubble({
               onClick={handleOpenUrl}
               className="block max-w-full rounded overflow-hidden focus:outline-none focus:ring-2 focus:ring-primary"
             >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={signedUrl}
                 alt={fileName}

--- a/components/messages/UnreadBadge.tsx
+++ b/components/messages/UnreadBadge.tsx
@@ -43,6 +43,7 @@ export function UnreadBadge({ initialCount, userId }: UnreadBadgeProps) {
 
   // Re-fetch whenever the user navigates (catches mark-as-read from conversation pages)
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchUnreadCount();
   }, [pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/components/news/news-grid.tsx
+++ b/components/news/news-grid.tsx
@@ -145,13 +145,13 @@ export function NewsGrid() {
             Subscribe to our newsletter and get updates on campaigns, events,
             and resources delivered straight to your inbox.
           </p>
-          <a
+          <Link
             href="/#newsletter"
             className="mt-6 inline-flex items-center gap-2 rounded-md bg-white px-6 py-2.5 text-sm font-semibold text-primary-orange transition-colors hover:bg-white/90"
           >
             Subscribe
             <ArrowRight className="size-4" />
-          </a>
+          </Link>
         </div>
       </div>
     </section>

--- a/components/profile/AvatarUpload.tsx
+++ b/components/profile/AvatarUpload.tsx
@@ -74,6 +74,7 @@ export function AvatarUpload({
           )}
         >
           {currentAvatarUrl && !uploading ? (
+            // eslint-disable-next-line @next/next/no-img-element
             <img src={currentAvatarUrl} alt="" className="size-full object-cover" />
           ) : (
             <span className="text-2xl">{initials}</span>

--- a/components/shared/LiveStatusAvatar.tsx
+++ b/components/shared/LiveStatusAvatar.tsx
@@ -22,6 +22,7 @@ export function LiveStatusAvatar({
   );
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setStatus(getOnlineStatus(lastSeenAt, { isCurrentUser }));
     const id = setInterval(() => {
       setStatus(getOnlineStatus(lastSeenAt, { isCurrentUser }));

--- a/lib/actionNetwork.ts
+++ b/lib/actionNetwork.ts
@@ -6,7 +6,7 @@ const ACTION_NETWORK_FORM_ID = process.env.ACTION_NETWORK_FORM_ID;
 if (!ACTION_NETWORK_API_KEY) {
   // Intentionally throw at module init in non-test environments so misconfig is obvious
   if (process.env.NODE_ENV !== "test") {
-    // eslint-disable-next-line no-console
+     
     console.warn(
       "[actionNetwork] ACTION_NETWORK_API_KEY is not set; newsletter signup will fail.",
     );

--- a/lib/events.test.ts
+++ b/lib/events.test.ts
@@ -46,47 +46,7 @@ function makeRsvps(counts: { going?: number; maybe?: number; declined?: number }
   return rows;
 }
 
-function buildMockClient(
-  eventData: Record<string, unknown> | null,
-  rsvps: RsvpRow[],
-  userRsvp: RsvpRow | null = null,
-  eventError: { message: string } | null = null
-) {
-  const mockClient = {
-    from: jest.fn((table: string) => {
-      if (table === "events") {
-        return {
-          select: jest.fn().mockReturnThis(),
-          eq: jest.fn().mockReturnThis(),
-          single: jest.fn().mockResolvedValue({
-            data: eventData,
-            error: eventError,
-          }),
-        };
-      }
-      // event_rsvps — called twice: once for all rsvps, once for user rsvp
-      let rsvpCallCount = 0;
-      const rsvpChain: Record<string, unknown> = {
-        select: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockImplementation(() => {
-          rsvpCallCount++;
-          return rsvpChain;
-        }),
-        maybeSingle: jest.fn().mockResolvedValue({
-          data: userRsvp,
-          error: null,
-        }),
-        then: jest.fn().mockImplementation((resolve: (v: unknown) => unknown) =>
-          Promise.resolve(resolve({ data: rsvps, error: null }))
-        ),
-      };
-      return rsvpChain;
-    }),
-  };
-  return mockClient;
-}
-
-// Simpler mock approach: build per-call interceptors
+// Build per-call interceptors
 function buildClientWithSequentialRsvps(
   eventData: Record<string, unknown> | null,
   allRsvps: RsvpRow[],

--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -1,7 +1,6 @@
 import {
   deleteFile,
   getSignedUrl,
-  uploadPrivateFile,
   uploadPublicFile,
   validateFile,
 } from './storage';

--- a/lib/utils/events.test.ts
+++ b/lib/utils/events.test.ts
@@ -14,7 +14,7 @@ describe('eventTypeConfig', () => {
   });
 
   it('provides label and color for each event type', () => {
-    for (const [key, value] of Object.entries(eventTypeConfig)) {
+    for (const [, value] of Object.entries(eventTypeConfig)) {
       expect(value.label).toBeTruthy();
       expect(value.color).toBeTruthy();
       expect(typeof value.label).toBe('string');


### PR DESCRIPTION
Intended to resolve all 67 remaining ESLint issues (25 errors, 42 warnings), allowing us to re enable eslint during each CI run. 

Note: this PR contains AI generated code changes :robot: 

**Phase 1: eslint --fix auto-corrections (f24d9d4)**

**Phase 2 — Errors (f63a30f)**
Suppressed 10 react-hooks/set-state-in-effect violations that are intentional patterns (prop sync, hydration, dialog reset, realtime subscriptions)
Fixed 12 react/no-unescaped-entities errors (apostrophes/quotes in JSX)
Replaced 2 raw <a> tags with next/link <Link> components

**Phase 3 — Warnings (4136cf8) (close review requested)**
Removed 24 unused imports and variables across components, tests, and server actions
Converted 5 ternary-as-statement expressions to if/else
Suppressed 2 exhaustive-deps warnings where dependency arrays are intentionally narrowed (polling interval, prop sync)
Suppressed 3 no-img-element warnings where next/image isn't viable (blob URLs, signed URLs, user avatars)
Removed dead buildMockClient helper from events.test.ts
Cleaned up catch (_err) → catch syntax
Removed unused user prop threading from LandingJoinCommunity

**Verification: npx eslint . returns 0 errors, 0 warnings.**


**Test plan:** 
  1. eslint + tsc --noEmit — confirm zero lint errors/warnings and clean types
  2. npm test — verify the 3 modified test files pass
  3. npm run build — catch any broken imports/props across all 48 files
  4. Manual smoke tests on 9 key pages — focus on the approveUser/rejectUser signature change, <a> → <Link> swaps, Set toggle interactions, and entity-escaped text rendering
  5. Diff review checklist — verify no behavioral changes snuck in

  The highest-risk item is the approveUser/rejectUser parameter removal — the callers use .bind(null, id) which should be fine, but the admin approval flow deserves a manual click-through.