### PR TITLE
fix: stick header and footer to top and bottom and add overflow-auto for scrollbars

### DIFF
--- a/app/(app)/messages/layout.tsx
+++ b/app/(app)/messages/layout.tsx
@@ -19,7 +19,7 @@ export default async function MessagesLayout({
   const notesId = selfNotesConversationId(user.id);
 
   return (
-    <div className="-m-4 lg:-m-6 flex h-[calc(100dvh-3.5rem)] overflow-hidden lg:h-dvh">
+    <div className="-m-4 lg:-m-6 flex h-[calc(100dvh-3.5rem)] overflow-auto lg:h-dvh">
       <div className="flex w-full shrink-0 flex-col border-r md:w-80">
         <ConversationList
           initialConversations={conversations}
@@ -27,7 +27,7 @@ export default async function MessagesLayout({
           selfNotesId={notesId}
         />
       </div>
-      <div className="hidden flex-1 flex-col min-w-0 md:flex">{children}</div>
+      <div className="hidden h-full min-h-0 flex-1 flex-col min-w-0 md:flex overflow-auto">{children}</div>
     </div>
   );
 }

--- a/components/messages/ConversationView.tsx
+++ b/components/messages/ConversationView.tsx
@@ -457,7 +457,7 @@ export function ConversationView({
 
     if (isGroup) {
       return (
-        <div className="flex items-center gap-2 border-b px-3 py-2.5 shrink-0 bg-background">
+        <div className="flex items-center gap-2 border-b px-3 py-2.5 shrink-0 sticky top-0 z-30 bg-background">
           <Link href="/messages">
             <Button variant="ghost" size="icon" className="md:hidden -ml-1">
               <ArrowLeft className="size-5" />
@@ -542,7 +542,7 @@ export function ConversationView({
           : "text-muted-foreground";
 
     return (
-      <div className="flex items-center gap-2 border-b px-3 py-2.5 shrink-0 bg-background">
+      <div className="flex items-center gap-2 border-b px-3 py-2.5 shrink-0 sticky top-0 z-30 bg-background">
         <Link href="/messages">
           <Button variant="ghost" size="icon" className="md:hidden -ml-1">
             <ArrowLeft className="size-5" />

--- a/components/messages/MessageInput.tsx
+++ b/components/messages/MessageInput.tsx
@@ -72,7 +72,7 @@ export function MessageInput({
   }
 
   return (
-    <div className="border-t bg-background px-4 py-3">
+    <div className="sticky bottom-0 z-30 border-t bg-background px-4 py-3">
       {attachment && (
         <div className="mb-2">
           <FileAttachmentPreview


### PR DESCRIPTION
### [Bug: Conversation List offset upward off screen when open conversation is long & scrolling not available for list or conversation](https://app.asana.com/1/1213515485882011/project/1213516055535837/task/1213990939107192?focus=true)

In all of the below cases, no scrolling is allowed either in the conversation list or the conversation itself.

### Before
Normal state:
<img width="1918" height="929" alt="image" src="https://github.com/user-attachments/assets/11afd114-27c8-4ef5-917c-88ac66aec858" />

Buggy state (conversation list partially off-screen):
<img width="1918" height="929" alt="image" src="https://github.com/user-attachments/assets/6006d322-83b9-4261-84d6-9fb8a617b8c3" />

Buggy state (conversation list fully off-screen):
<img width="1908" height="924" alt="image" src="https://github.com/user-attachments/assets/170a3be8-8171-4a07-bbbd-7d8893e533eb" />

### After
<img width="1920" height="951" alt="image" src="https://github.com/user-attachments/assets/d064fd15-2119-404f-84f9-5af1692355ff" />

