### PR TITLE
docs: Update README with service role key

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Create `.env.local` in the project root:
 ```env
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 ```
 
 Optional (for Jitsi JWT / 8x8 JaaS):


### PR DESCRIPTION
Add supabase SUPABASE_SERVICE_ROLE_KEY env variable to setup docs.

I'm not sure why this was missing from the README setup instructions, but I'm assuming it wasn't intentional. I seem to need it to post messages to groups.