### PR TITLE
fix(email-domain): set NEXT_PUBLIC_SITE_URL correctly in prod

### DIFF
--- a/.env.preview
+++ b/.env.preview
@@ -1,0 +1,2 @@
+# .env.production
+NEXT_PUBLIC_SITE_URL=

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
 # .env.production
-# NEXT_PUBLIC_SITE_URL is derived in next.config.ts from VERCEL_URL
+NEXT_PUBLIC_SITE_URL=https://wwwrise.org


### PR DESCRIPTION
I am still testing this, but this should fix the issue where prod emails contain links using the vercel domain. 

There is a chance this could break prod if the config files don't work the way I expect them to.