### PR TITLE
fix: reset EditJobForm state when selected job changes

### DIFF
--- a/app/(app)/jobs/JobBoardClient.tsx
+++ b/app/(app)/jobs/JobBoardClient.tsx
@@ -339,7 +339,7 @@ export function JobBoardClient({
                   </div>
                   {(isPlatformAdmin || selectedJob.posted_by === currentUserId) && (
                     <div className="flex items-center gap-1 shrink-0">
-                      <EditJobForm job={selectedJob} />
+                      <EditJobForm key={selectedJob.id} job={selectedJob} />
                       <DeleteJobButton id={selectedJob.id} />
                     </div>
                   )}


### PR DESCRIPTION
## Summary

- Adds `key={selectedJob.id}` to `<EditJobForm>` in `JobBoardClient.tsx`
- Forces React to remount the form with fresh state whenever a different job is selected, preventing stale data from a previously viewed job pre-filling the edit form

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)