### PR TITLE
infra: switch production deploy to manual trigger

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,9 +1,7 @@
 name: Production Deploy
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary
- Replaces the `push` to `main` trigger with `workflow_dispatch` so production deploys are manually initiated
- Can be triggered from any branch via Actions tab → Production Deploy → Run workflow

## Test plan
- [x] Merge to main and confirm the workflow no longer auto-runs on push
- [ ] Manually trigger from Actions tab and confirm deploy runs as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)