### PR TITLE
Resolve merge conflict and update messages + migration + deletion fix

### DIFF
--- a/app/(app)/messages/[conversationId]/page.tsx
+++ b/app/(app)/messages/[conversationId]/page.tsx
@@ -15,7 +15,10 @@ export default async function ConversationPage({
 }: ConversationPageProps) {
   const { conversationId } = await params;
   const resolvedSearchParams = await searchParams;
-  const videoRoom = typeof resolvedSearchParams?.videoRoom === "string" ? resolvedSearchParams.videoRoom : null;
+  const videoRoom =
+    typeof resolvedSearchParams?.videoRoom === "string"
+      ? resolvedSearchParams.videoRoom
+      : null;
 
   const supabase = await createClient();
   const {
@@ -32,7 +35,10 @@ export default async function ConversationPage({
     .maybeSingle();
 
   if (myParticipationError) {
-    console.error("[conversation] myParticipation error:", myParticipationError);
+    console.error(
+      "[conversation] myParticipation error:",
+      myParticipationError,
+    );
   }
 
   if (!myParticipation) {
@@ -40,7 +46,12 @@ export default async function ConversationPage({
     if (conversationId === selfNotesConversationId(user.id)) {
       await getOrCreateSelfNotes(user.id);
     } else {
-      console.error("[conversation] user", user.id, "is not a participant in", conversationId);
+      console.error(
+        "[conversation] user",
+        user.id,
+        "is not a participant in",
+        conversationId,
+      );
       redirect("/messages");
     }
   }
@@ -66,6 +77,13 @@ export default async function ConversationPage({
     display_name: currentUserProfile?.display_name ?? "You",
     avatar_url: currentUserProfile?.avatar_url ?? null,
   };
+
+  const { data: deletions } = await supabase
+    .from("message_deletions")
+    .select("message_id")
+    .eq("user_id", user.id);
+
+  const deletedMessageIds = new Set((deletions ?? []).map((d) => d.message_id));
 
   // ── Group conversation ────────────────────────────────────────────────────
   if (conversation.type === "group") {
@@ -93,25 +111,37 @@ export default async function ConversationPage({
 
     // Build profile cache for messages
     const profileCache = new Map<string, Profile>(
-      participants.map((p) => [p.id, p])
+      participants.map((p) => [p.id, p]),
     );
 
     const { data: rawMessages } = await supabase
       .from("messages")
       .select(
-        "id, conversation_id, sender_id, content, message_type, metadata, edited_at, created_at"
+        `
+    id, 
+    conversation_id, 
+    sender_id, 
+    content, 
+    message_type, 
+    metadata, 
+    edited_at, 
+    created_at
+  `,
       )
       .eq("conversation_id", conversationId)
       .order("created_at", { ascending: false })
       .limit(50);
 
     const messages: MessageWithSender[] = (rawMessages ?? [])
+      .filter((msg) => !deletedMessageIds.has(msg.id))
       .reverse()
       .map((msg) => ({
         ...msg,
         message_type: msg.message_type as MessageWithSender["message_type"],
         metadata: (msg.metadata ?? {}) as Record<string, unknown>,
-        sender: msg.sender_id ? (profileCache.get(msg.sender_id) ?? null) : null,
+        sender: msg.sender_id
+          ? (profileCache.get(msg.sender_id) ?? null)
+          : null,
       }));
 
     await supabase
@@ -138,29 +168,45 @@ export default async function ConversationPage({
   }
 
   // ── DM conversation ───────────────────────────────────────────────────────
-  const { data: otherParticipant, error: otherParticipantError } = await supabase
-    .from("conversation_participants")
-    .select("user_id")
-    .eq("conversation_id", conversationId)
-    .neq("user_id", user.id)
-    .maybeSingle();
+  const { data: otherParticipant, error: otherParticipantError } =
+    await supabase
+      .from("conversation_participants")
+      .select("user_id")
+      .eq("conversation_id", conversationId)
+      .neq("user_id", user.id)
+      .maybeSingle();
 
   if (otherParticipantError) {
-    console.error("[conversation] otherParticipant error:", otherParticipantError);
+    console.error(
+      "[conversation] otherParticipant error:",
+      otherParticipantError,
+    );
   }
 
   // Self-notes conversation: no other participant expected
-  const isSelfNotes = !otherParticipant && conversationId === selfNotesConversationId(user.id);
+  const isSelfNotes =
+    !otherParticipant && conversationId === selfNotesConversationId(user.id);
 
   if (!otherParticipant && !isSelfNotes) {
-    console.error("[conversation] no other participant found in", conversationId);
+    console.error(
+      "[conversation] no other participant found in",
+      conversationId,
+    );
     redirect("/messages");
   }
 
   const { data: rawMessages } = await supabase
     .from("messages")
     .select(
-      "id, conversation_id, sender_id, content, message_type, metadata, edited_at, created_at"
+      `
+    id, 
+    conversation_id, 
+    sender_id, content, 
+    message_type, 
+    metadata, 
+    edited_at, 
+    created_at
+  `,
     )
     .eq("conversation_id", conversationId)
     .order("created_at", { ascending: false })
@@ -175,12 +221,15 @@ export default async function ConversationPage({
             .select("*")
             .eq("id", otherParticipant.user_id)
             .single();
-          return p ? [[otherParticipant.user_id, p as Profile] as [string, Profile]] : [];
+          return p
+            ? [[otherParticipant.user_id, p as Profile] as [string, Profile]]
+            : [];
         })()
       : []),
   ]);
 
   const messages: MessageWithSender[] = (rawMessages ?? [])
+    .filter((msg) => !deletedMessageIds.has(msg.id))
     .reverse()
     .map((msg) => ({
       ...msg,
@@ -211,7 +260,10 @@ export default async function ConversationPage({
 
   const otherUserProfile = profileCache.get(otherParticipant!.user_id);
   if (!otherUserProfile) {
-    console.error("[conversation] other user profile not found:", otherParticipant!.user_id);
+    console.error(
+      "[conversation] other user profile not found:",
+      otherParticipant!.user_id,
+    );
     redirect("/messages");
   }
 

--- a/app/(app)/messages/[conversationId]/page.tsx
+++ b/app/(app)/messages/[conversationId]/page.tsx
@@ -78,13 +78,6 @@ export default async function ConversationPage({
     avatar_url: currentUserProfile?.avatar_url ?? null,
   };
 
-  // const { data: deletions } = await supabase
-  //   .from("message_deletions")
-  //   .select("message_id")
-  //   .eq("user_id", user.id);
-
-  // const deletedMessageIds = new Set((deletions ?? []).map((d) => d.message_id));
-
   // ── Group conversation ────────────────────────────────────────────────────
   if (conversation.type === "group") {
     // Fetch group info

--- a/app/(app)/messages/[conversationId]/page.tsx
+++ b/app/(app)/messages/[conversationId]/page.tsx
@@ -78,12 +78,12 @@ export default async function ConversationPage({
     avatar_url: currentUserProfile?.avatar_url ?? null,
   };
 
-  const { data: deletions } = await supabase
-    .from("message_deletions")
-    .select("message_id")
-    .eq("user_id", user.id);
+  // const { data: deletions } = await supabase
+  //   .from("message_deletions")
+  //   .select("message_id")
+  //   .eq("user_id", user.id);
 
-  const deletedMessageIds = new Set((deletions ?? []).map((d) => d.message_id));
+  // const deletedMessageIds = new Set((deletions ?? []).map((d) => d.message_id));
 
   // ── Group conversation ────────────────────────────────────────────────────
   if (conversation.type === "group") {
@@ -131,6 +131,23 @@ export default async function ConversationPage({
       .eq("conversation_id", conversationId)
       .order("created_at", { ascending: false })
       .limit(50);
+
+    const { data: deletions, error: deletionsError } = await supabase
+      .from("message_deletions")
+      .select("message_id")
+      .eq("user_id", user.id)
+      .in("message_id", (rawMessages ?? []).map((m) => m.id));
+
+    if (deletionsError) {
+      console.error(
+        "[conversation] deletions fetch error:",
+        deletionsError,
+      );
+    }
+
+    const deletedMessageIds = new Set(
+      (deletions ?? []).map((d) => d.message_id),
+    );
 
     const messages: MessageWithSender[] = (rawMessages ?? [])
       .filter((msg) => !deletedMessageIds.has(msg.id))
@@ -211,6 +228,23 @@ export default async function ConversationPage({
     .eq("conversation_id", conversationId)
     .order("created_at", { ascending: false })
     .limit(50);
+
+  const { data: deletions, error: deletionsError } = await supabase
+    .from("message_deletions")
+    .select("message_id")
+    .eq("user_id", user.id)
+    .in("message_id", (rawMessages ?? []).map((m) => m.id));
+
+  if (deletionsError) {
+    console.error(
+      "[conversation] deletions fetch error:",
+      deletionsError,
+    );
+  }
+
+  const deletedMessageIds = new Set(
+    (deletions ?? []).map((d) => d.message_id),
+  );
 
   const profileCache = new Map<string, Profile>([
     [user.id, currentUserProfile as Profile],

--- a/components/messages/ConversationList.tsx
+++ b/components/messages/ConversationList.tsx
@@ -10,7 +10,7 @@ import { getAvatarColor } from "@/lib/utils/avatar";
 import { formatRelativeTime } from "@/lib/utils/time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { UsersRound, Archive, Video, BookMarked } from "lucide-react";
+import { UsersRound, Archive, Video, BookMarked, Trash2 } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -46,7 +46,10 @@ export function ConversationList({
   }, [pathname]);
 
   const prevInitialIdsRef = useRef(
-    initialConversations.map((c) => c.conversation.id).sort().join(",")
+    initialConversations
+      .map((c) => c.conversation.id)
+      .sort()
+      .join(","),
   );
 
   // Sync from server when initialConversations gains new conversations (e.g. after starting a new thread + refresh)
@@ -70,8 +73,8 @@ export function ConversationList({
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setConversations((prev) =>
       prev.map((c) =>
-        c.conversation.id === convId ? { ...c, unreadCount: 0 } : c
-      )
+        c.conversation.id === convId ? { ...c, unreadCount: 0 } : c,
+      ),
     );
   }, [pathname]);
 
@@ -93,7 +96,7 @@ export function ConversationList({
         },
         () => {
           router.refresh();
-        }
+        },
       )
       .on(
         "postgres_changes",
@@ -112,7 +115,7 @@ export function ConversationList({
 
           setConversations((prev) => {
             const idx = prev.findIndex(
-              (c) => c.conversation.id === newMsg.conversation_id
+              (c) => c.conversation.id === newMsg.conversation_id,
             );
 
             const updated = [...prev];
@@ -127,7 +130,7 @@ export function ConversationList({
             updated.splice(idx, 1);
             return [conv, ...updated];
           });
-        }
+        },
       )
       .subscribe();
 
@@ -135,6 +138,37 @@ export function ConversationList({
       supabase.removeChannel(channel);
     };
   }, [currentUserId, router]);
+
+  const [isDeleting, setIsDeleting] = useState<string | null>(null);
+
+  async function handleDelete(e: React.MouseEvent, conversationId: string) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    setIsDeleting(conversationId);
+
+    const supabase = createClient();
+
+    await supabase
+      .from("conversation_participants")
+      .update({
+        deleted_at: new Date().toISOString(),
+      })
+      .eq("conversation_id", conversationId)
+      .eq("user_id", currentUserId);
+
+    setConversations((prev) =>
+      prev.filter((c) => c.conversation.id !== conversationId),
+    );
+
+    if (pathname === `/messages/${conversationId}`) {
+      router.push("/messages");
+    }
+
+    router.refresh();
+
+    setIsDeleting(null);
+  }
 
   async function handleArchive(e: React.MouseEvent, conversationId: string) {
     e.preventDefault();
@@ -145,7 +179,9 @@ export function ConversationList({
       .update({ archived: true })
       .eq("conversation_id", conversationId)
       .eq("user_id", currentUserId);
-    setConversations((prev) => prev.filter((c) => c.conversation.id !== conversationId));
+    setConversations((prev) =>
+      prev.filter((c) => c.conversation.id !== conversationId),
+    );
     if (pathname === `/messages/${conversationId}`) {
       router.push("/messages");
     }
@@ -165,14 +201,16 @@ export function ConversationList({
         {/* My Notes — always pinned at top */}
         {(() => {
           const isNotesActive = pathname === `/messages/${selfNotesId}`;
-          const notesConv = conversations.find((c) => c.conversation.id === selfNotesId);
+          const notesConv = conversations.find(
+            (c) => c.conversation.id === selfNotesId,
+          );
           const lastNoteMsg = notesConv?.lastMessage;
           return (
             <Link
               href={`/messages/${selfNotesId}`}
               className={cn(
                 "flex items-center gap-3 border-b px-4 py-3 transition-colors hover:bg-accent",
-                isNotesActive && "bg-accent"
+                isNotesActive && "bg-accent",
               )}
             >
               <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
@@ -195,67 +233,189 @@ export function ConversationList({
           );
         })()}
 
-        {conversations.filter((c) => c.conversation.id !== selfNotesId).length === 0 ? (
+        {conversations.filter((c) => c.conversation.id !== selfNotesId)
+          .length === 0 ? (
           <div className="flex flex-col items-center justify-center h-40 text-center px-6">
-            <p className="text-sm text-muted-foreground">No conversations yet.</p>
+            <p className="text-sm text-muted-foreground">
+              No conversations yet.
+            </p>
             <p className="text-xs text-muted-foreground mt-1">
               Message a member to get started.
             </p>
           </div>
         ) : (
-          conversations.filter((c) => c.conversation.id !== selfNotesId).map(
-            ({ conversation, participants, lastMessage, unreadCount, groupName }) => {
-              const isActive = pathname === `/messages/${conversation.id}`;
-              const hasUnread = unreadCount > 0;
-              const isGroupConv = conversation.type === "group";
+          conversations
+            .filter((c) => c.conversation.id !== selfNotesId)
+            .map(
+              ({
+                conversation,
+                participants,
+                lastMessage,
+                unreadCount,
+                groupName,
+                groupSlug,
+              }) => {
+                const isActive = pathname === `/messages/${conversation.id}`;
+                const hasUnread = unreadCount > 0;
+                const isGroupConv = conversation.type === "group";
 
-              const isPendingCall =
-                lastMessage?.message_type === "video_invite" &&
-                lastMessage.sender_id !== currentUserId;
+                const isPendingCall =
+                  lastMessage?.message_type === "video_invite" &&
+                  lastMessage.sender_id !== currentUserId;
 
-              if (isGroupConv) {
+                if (isGroupConv) {
+                  return (
+                    <div
+                      key={conversation.id}
+                      className={cn(
+                        "flex items-center gap-1 border-b px-4 py-3 transition-colors hover:bg-accent",
+                        isActive && "bg-accent",
+                      )}
+                    >
+                      <Link
+                        href={`/messages/${conversation.id}`}
+                        className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
+                      >
+                        {/* Group icon avatar */}
+                        <div className="relative shrink-0">
+                          <div
+                            className={cn(
+                              "flex size-10 items-center justify-center rounded-full text-white text-sm font-semibold",
+                              getAvatarColor(groupName ?? "Group"),
+                            )}
+                          >
+                            <UsersRound className="size-4" />
+                          </div>
+                        </div>
+
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="flex items-center gap-1.5 min-w-0">
+                              <p
+                                className={cn(
+                                  "text-sm truncate",
+                                  hasUnread ? "font-semibold" : "font-medium",
+                                )}
+                              >
+                                {groupName ?? "Group"}
+                              </p>
+                              <Badge
+                                variant="secondary"
+                                className="shrink-0 text-[10px] px-1.5 py-0 h-4"
+                              >
+                                Group
+                              </Badge>
+                            </div>
+                            {lastMessage && (
+                              <span className="text-[11px] text-muted-foreground shrink-0">
+                                {formatRelativeTime(lastMessage.created_at)}
+                              </span>
+                            )}
+                          </div>
+
+                          <div className="flex items-center justify-between gap-2 mt-0.5">
+                            <p
+                              className={cn(
+                                "text-xs truncate",
+                                hasUnread
+                                  ? "font-medium text-foreground"
+                                  : "text-muted-foreground",
+                              )}
+                            >
+                              {lastMessage
+                                ? lastMessage.message_type === "system"
+                                  ? lastMessage.content
+                                  : lastMessage.message_type === "video_invite"
+                                    ? lastMessage.sender_id === currentUserId
+                                      ? "You started a video call"
+                                      : "Incoming video call"
+                                    : `${lastMessage.sender_id === currentUserId ? "You: " : ""}${lastMessage.content}`
+                                : "No messages yet"}
+                            </p>
+                            {isPendingCall ? (
+                              <span className="shrink-0 flex items-center gap-1 rounded-full bg-green-500 text-white px-2 py-0.5 text-[10px] font-semibold animate-pulse">
+                                <Video className="size-3" />
+                                Incoming call
+                              </span>
+                            ) : hasUnread ? (
+                              <Badge
+                                variant="destructive"
+                                className="shrink-0 h-4 min-w-4 px-1 text-[10px] flex items-center justify-center"
+                              >
+                                {unreadCount > 99 ? "99+" : unreadCount}
+                              </Badge>
+                            ) : null}
+                          </div>
+                        </div>
+                      </Link>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-8 shrink-0"
+                              disabled={isDeleting === conversation.id}
+                              onClick={(e) => handleDelete(e, conversation.id)}
+                            >
+                              <Trash2 className="size-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Delete conversation</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-8 shrink-0"
+                              onClick={(e) => handleArchive(e, conversation.id)}
+                            >
+                              <Archive className="size-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Archive conversation</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+                  );
+                }
+
+                // DM row
+                const otherUser = participants[0];
+                if (!otherUser) return null;
+
                 return (
                   <div
                     key={conversation.id}
                     className={cn(
                       "flex items-center gap-1 border-b px-4 py-3 transition-colors hover:bg-accent",
-                      isActive && "bg-accent"
+                      isActive && "bg-accent",
                     )}
                   >
                     <Link
                       href={`/messages/${conversation.id}`}
                       className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
                     >
-                      {/* Group icon avatar */}
-                      <div className="relative shrink-0">
-                        <div
-                          className={cn(
-                            "flex size-10 items-center justify-center rounded-full text-white text-sm font-semibold",
-                            getAvatarColor(groupName ?? "Group")
-                          )}
-                        >
-                          <UsersRound className="size-4" />
-                        </div>
-                      </div>
+                      <LiveStatusAvatar
+                        avatarUrl={otherUser.avatar_url ?? null}
+                        displayName={otherUser.display_name}
+                        size="md"
+                        lastSeenAt={otherUser.last_seen_at}
+                      />
 
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center justify-between gap-2">
-                          <div className="flex items-center gap-1.5 min-w-0">
-                            <p
-                              className={cn(
-                                "text-sm truncate",
-                                hasUnread ? "font-semibold" : "font-medium"
-                              )}
-                            >
-                              {groupName ?? "Group"}
-                            </p>
-                            <Badge
-                              variant="secondary"
-                              className="shrink-0 text-[10px] px-1.5 py-0 h-4"
-                            >
-                              Group
-                            </Badge>
-                          </div>
+                          <p
+                            className={cn(
+                              "text-sm truncate",
+                              hasUnread ? "font-semibold" : "font-medium",
+                            )}
+                          >
+                            {otherUser.display_name}
+                          </p>
                           {lastMessage && (
                             <span className="text-[11px] text-muted-foreground shrink-0">
                               {formatRelativeTime(lastMessage.created_at)}
@@ -269,7 +429,7 @@ export function ConversationList({
                               "text-xs truncate",
                               hasUnread
                                 ? "font-medium text-foreground"
-                                : "text-muted-foreground"
+                                : "text-muted-foreground",
                             )}
                           >
                             {lastMessage
@@ -315,102 +475,8 @@ export function ConversationList({
                     </TooltipProvider>
                   </div>
                 );
-              }
-
-              // DM row
-              const otherUser = participants[0];
-              if (!otherUser) return null;
-
-              return (
-                <div
-                  key={conversation.id}
-                  className={cn(
-                    "flex items-center gap-1 border-b px-4 py-3 transition-colors hover:bg-accent",
-                    isActive && "bg-accent"
-                  )}
-                >
-                  <Link
-                    href={`/messages/${conversation.id}`}
-                    className="flex min-w-0 flex-1 items-center gap-3 py-0.5 -my-0.5 -mx-1 px-1 rounded-md hover:bg-transparent"
-                  >
-                    <LiveStatusAvatar
-                      avatarUrl={otherUser.avatar_url ?? null}
-                      displayName={otherUser.display_name}
-                      size="md"
-                      lastSeenAt={otherUser.last_seen_at}
-                    />
-
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center justify-between gap-2">
-                        <p
-                          className={cn(
-                            "text-sm truncate",
-                            hasUnread ? "font-semibold" : "font-medium"
-                          )}
-                        >
-                          {otherUser.display_name}
-                        </p>
-                        {lastMessage && (
-                          <span className="text-[11px] text-muted-foreground shrink-0">
-                            {formatRelativeTime(lastMessage.created_at)}
-                          </span>
-                        )}
-                      </div>
-
-                      <div className="flex items-center justify-between gap-2 mt-0.5">
-                        <p
-                          className={cn(
-                            "text-xs truncate",
-                            hasUnread
-                              ? "font-medium text-foreground"
-                              : "text-muted-foreground"
-                          )}
-                        >
-                          {lastMessage
-                            ? lastMessage.message_type === "system"
-                              ? lastMessage.content
-                              : lastMessage.message_type === "video_invite"
-                                ? lastMessage.sender_id === currentUserId
-                                  ? "You started a video call"
-                                  : "Incoming video call"
-                                : `${lastMessage.sender_id === currentUserId ? "You: " : ""}${lastMessage.content}`
-                            : "No messages yet"}
-                        </p>
-                        {isPendingCall ? (
-                          <span className="shrink-0 flex items-center gap-1 rounded-full bg-green-500 text-white px-2 py-0.5 text-[10px] font-semibold animate-pulse">
-                            <Video className="size-3" />
-                            Incoming call
-                          </span>
-                        ) : hasUnread ? (
-                          <Badge
-                            variant="destructive"
-                            className="shrink-0 h-4 min-w-4 px-1 text-[10px] flex items-center justify-center"
-                          >
-                            {unreadCount > 99 ? "99+" : unreadCount}
-                          </Badge>
-                        ) : null}
-                      </div>
-                    </div>
-                  </Link>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="size-8 shrink-0"
-                          onClick={(e) => handleArchive(e, conversation.id)}
-                        >
-                          <Archive className="size-4" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Archive conversation</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              );
-            }
-          )
+              },
+            )
         )}
       </div>
     </div>

--- a/components/messages/ConversationList.tsx
+++ b/components/messages/ConversationList.tsx
@@ -149,13 +149,20 @@ export function ConversationList({
 
     const supabase = createClient();
 
-    await supabase
-      .from("conversation_participants")
-      .update({
-        deleted_at: new Date().toISOString(),
-      })
-      .eq("conversation_id", conversationId)
-      .eq("user_id", currentUserId);
+  const { error } = await supabase
+    .from("conversation_participants")
+    .update({
+      deleted_at: new Date().toISOString(),
+    })
+    .eq("conversation_id", conversationId)
+    .eq("user_id", currentUserId);
+
+  setIsDeleting(null);
+
+if (error) {
+  console.error("[conversation] delete failed:", error);
+  return;
+}
 
     setConversations((prev) =>
       prev.filter((c) => c.conversation.id !== conversationId),
@@ -164,9 +171,6 @@ export function ConversationList({
     if (pathname === `/messages/${conversationId}`) {
       router.push("/messages");
     }
-
-    router.refresh();
-
     setIsDeleting(null);
   }
 
@@ -185,7 +189,6 @@ export function ConversationList({
     if (pathname === `/messages/${conversationId}`) {
       router.push("/messages");
     }
-    router.refresh();
   }
 
   return (
@@ -253,7 +256,6 @@ export function ConversationList({
                 lastMessage,
                 unreadCount,
                 groupName,
-                groupSlug,
               }) => {
                 const isActive = pathname === `/messages/${conversation.id}`;
                 const hasUnread = unreadCount > 0;
@@ -471,6 +473,22 @@ export function ConversationList({
                           </Button>
                         </TooltipTrigger>
                         <TooltipContent>Archive conversation</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-8 shrink-0"
+                            disabled={isDeleting === conversation.id}
+                            onClick={(e) => handleDelete(e, conversation.id)}
+                            >
+                          <Trash2 className="size-4" />
+                          </Button>
+                        </TooltipTrigger>
+                         <TooltipContent>Delete conversation</TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
                   </div>

--- a/supabase/migrations/20260501152108_create_message_deletions.sql
+++ b/supabase/migrations/20260501152108_create_message_deletions.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS message_deletions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id uuid NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  deleted_at timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE(message_id, user_id)
+);

--- a/supabase/migrations/20260501152108_create_message_deletions.sql
+++ b/supabase/migrations/20260501152108_create_message_deletions.sql
@@ -6,3 +6,11 @@ CREATE TABLE IF NOT EXISTS message_deletions (
 
   UNIQUE(message_id, user_id)
 );
+
+ALTER TABLE message_deletions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users manage own deletions"
+  ON message_deletions
+  FOR ALL
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());

--- a/supabase/migrations/20260501152108_create_message_deletions.sql
+++ b/supabase/migrations/20260501152108_create_message_deletions.sql
@@ -14,3 +14,4 @@ CREATE POLICY "users manage own deletions"
   FOR ALL
   USING (user_id = auth.uid())
   WITH CHECK (user_id = auth.uid());
+  


### PR DESCRIPTION
Message delete

In ConversationsList

Line 13:
Added the import: Trash2


Line 124:
const [isDeleting, setIsDeleting] = useState<string | null>(null);

Lines 126-156:
async function handleDelete(
  e: React.MouseEvent,
  conversationId: string
) {
  e.preventDefault();
  e.stopPropagation();

  setIsDeleting(conversationId);

  const supabase = createClient();

  await supabase
    .from("conversation_participants")
    .update({
      deleted_at: new Date().toISOString(),
    })
    .eq("conversation_id", conversationId)
    .eq("user_id", currentUserId);

  setConversations((prev) =>
    prev.filter((c) => c.conversation.id !== conversationId)
  );

  if (pathname === `/messages/${conversationId}`) {
    router.push("/messages");
  }

  router.refresh();

  setIsDeleting(null);
}

Line 321-335:
<TooltipProvider>
  <Tooltip>
    <TooltipTrigger asChild>
      <Button
        variant="ghost"
        size="icon"
        className="size-8 shrink-0"
        disabled={isDeleting === conversation.id}
        onClick={(e) => handleDelete(e, conversation.id)}
      >
        <Trash2 className="size-4" />
      </Button>
    </TooltipTrigger>
    <TooltipContent>Delete conversation</TooltipContent>
  </Tooltip>
</TooltipProvider>


Backend:

Created new migration at supabase/migrations/20260501152108_create_message_deletions.sql
 CREATE TABLE IF NOT EXISTS message_deletions (
  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
  message_id uuid NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
  deleted_at timestamptz NOT NULL DEFAULT now(),

  UNIQUE(message_id, user_id)
);

In: community-platform/app/(app)/messages/[conversationId]/page.tsx 
Lines 70-77 const { data: deletions } = await supabase
.from("message_deletions")
.select("message_id")
.eq("user_id", user.id);
  const deletedMessageIds = new Set(
        (deletions ?? []).map((d) => d.message_id)
      );

Lines 118 & 194
Reversed the order of .reverse & .filter 

This is not exact, because of a long merge conflict battle.  Trying to push the cleanest message soft delete I can with no extraneous code.  
- Resolved merge conflict in ConversationList.tsx
- Updated messages page logic
- Added migration for message deletions
- Improved real-time conversation updates