### PR TITLE
fix: resolve #116 — Avatar upload size limit too small at 2 MB

### DIFF
--- a/components/profile/AvatarUpload.tsx
+++ b/components/profile/AvatarUpload.tsx
@@ -6,8 +6,52 @@ import { cn } from "@/lib/utils";
 import { getAvatarColor, getInitials } from "@/lib/utils/avatar";
 import { uploadPublicFile, validateFile } from "@/lib/storage";
 
-const AVATAR_LIMIT_MB = 2;
+const AVATAR_LIMIT_MB = 10;
 const AVATAR_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"];
+
+async function compressImage(file: File): Promise<File> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(img.src);
+      let width = img.width;
+      let height = img.height;
+      const maxSize = 1024;
+      if (width > maxSize || height > maxSize) {
+        if (width > height) {
+          height = (height / width) * maxSize;
+          width = maxSize;
+        } else {
+          width = (width / height) * maxSize;
+          height = maxSize;
+        }
+      }
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d");
+      ctx?.drawImage(img, 0, 0, width, height);
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            const newFileName = file.name.replace(/\.[^/.]+$/, ".jpg");
+            const compressedFile = new File([blob], newFileName, { type: "image/jpeg" });
+            resolve(compressedFile);
+          } else {
+            reject(new Error("Compression failed"));
+          }
+        },
+        "image/jpeg",
+        0.7
+      );
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(img.src);
+      reject(new Error("Failed to load image"));
+    };
+    img.src = URL.createObjectURL(file);
+  });
+}
 
 interface AvatarUploadProps {
   userId: string;
@@ -44,10 +88,18 @@ export function AvatarUpload({
     }
 
     setUploading(true);
-    const ext = file.name.split(".").pop()?.toLowerCase() || "jpg";
+    let uploadFile = file;
+    let ext = file.name.split(".").pop()?.toLowerCase() || "jpg";
+    try {
+      const compressed = await compressImage(file);
+      uploadFile = compressed;
+      ext = "jpg";
+    } catch {
+      // Fall back to original file
+    }
     const path = `${userId}/avatar.${ext}`;
 
-    const result = await uploadPublicFile("avatars", path, file);
+    const result = await uploadPublicFile("avatars", path, uploadFile);
 
     setUploading(false);
     if (result.error) {


### PR DESCRIPTION
## Summary

fix: resolve #116 — Avatar upload size limit too small at 2 MB

## Problem

**Severity**: `Medium` | **File**: `components/profile/AvatarUpload.tsx`

The current 2 MB limit is too restrictive for many modern phone photos. This change increases the client-side limit to 10 MB and introduces image compression before upload, reducing the actual file size sent to the server. Compression uses the browser’s Canvas API to resize the image (max 1024x1024) and adjust JPEG quality to ~70%, typically resulting in a file under 1 MB without noticeable quality loss for avatars.

## Solution



## Changes

- `components/profile/AvatarUpload.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"