### PR TITLE
fix: resolve #125 - Unable to start new conversation after selecting a member

### DIFF
--- a/components/messages/NewMessageDialog.tsx
+++ b/components/messages/NewMessageDialog.tsx
@@ -61,7 +61,6 @@ export function NewMessageDialog() {
     setResults([]);
     setOpening(false);
     router.push(`/messages/${conversationId}`);
-    router.refresh();
   }
 
   return (


### PR DESCRIPTION
Closes https://github.com/What-We-Will/community-platform/issues/125, so long as navigation to the new conversation is the only actual issue (there may be more to it I am not seeing). 

In Next.js App Router, `router.refresh()` races against previously called `router.push()` and interrupts the in-flight navigation to the newly created conversation thread. Solution is to remove `router.refresh()` and the rendering of the thread is restored.