### PR TITLE
fix: resolve #108 - Member search cycles and jumps between values while typing

### DIFF
--- a/components/members/MemberFilters.tsx
+++ b/components/members/MemberFilters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -22,31 +22,21 @@ interface MemberFiltersProps {
 export default function MemberFilters({ allSkills }: MemberFiltersProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [searchInput, setSearchInput] = useState(
-    () => searchParams.get("q") ?? ""
-  );
-  const [debouncedSearch, setDebouncedSearch] = useState(
-    () => searchParams.get("q") ?? ""
-  );
 
-  // Sync local state when URL changes (e.g. browser back/forward)
+  const inputRef = useRef<HTMLInputElement>(null);
+  const lastPushedQ = useRef(searchParams.get("q") ?? "");
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
   useEffect(() => {
     const q = searchParams.get("q") ?? "";
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSearchInput(q);
-    setDebouncedSearch(q);
+    if (q !== lastPushedQ.current) {
+      if (inputRef.current) inputRef.current.value = q;
+      lastPushedQ.current = q;
+    }
   }, [searchParams]);
 
   const skill = searchParams.get("skill") ?? "";
   const referrals = searchParams.get("referrals") === "true";
-
-  // Debounce search input
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchInput);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
 
   const updateParams = useCallback(
     (updates: { q?: string; skill?: string; referrals?: string }) => {
@@ -68,24 +58,29 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
     [router, searchParams]
   );
 
-  // Sync URL when debounced search changes
-  useEffect(() => {
-    const currentQ = searchParams.get("q") ?? "";
-    if (debouncedSearch !== currentQ) {
-      updateParams({ q: debouncedSearch });
-    }
-  }, [debouncedSearch, updateParams, searchParams]);
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(() => {
+        lastPushedQ.current = value;
+        updateParams({ q: value });
+      }, SEARCH_DEBOUNCE_MS);
+    },
+    [updateParams]
+  );
 
   return (
     <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
       <div className="flex-1 space-y-2">
         <Label htmlFor="search">Search</Label>
         <Input
+          ref={inputRef}
           id="search"
           type="search"
           placeholder="Search by name, role, or location..."
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
+          defaultValue={searchParams.get("q") ?? ""}
+          onChange={handleSearchChange}
         />
       </div>
       <div className="space-y-2">

--- a/components/members/MemberFilters.tsx
+++ b/components/members/MemberFilters.tsx
@@ -24,15 +24,22 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
   const searchParams = useSearchParams();
 
   const inputRef = useRef<HTMLInputElement>(null);
-  const lastPushedQ = useRef(searchParams.get("q") ?? "");
+  // Last q we wrote to the URL via push OR replace — lets the external-nav
+  // sync below distinguish back/forward from our own writes.
+  const lastUrlQ = useRef(searchParams.get("q") ?? "");
+  // Last q committed via push (Enter / blur / filter change). commitSearch
+  // dedupes against this — not against lastUrlQ — so Enter after a
+  // debounce-replace still creates a real history entry.
+  const lastCommittedQ = useRef(searchParams.get("q") ?? "");
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // External navigation sync (back / forward only)
   useEffect(() => {
     const q = searchParams.get("q") ?? "";
-    if (q !== lastPushedQ.current) {
+    if (q !== lastUrlQ.current) {
       if (inputRef.current) inputRef.current.value = q;
-      lastPushedQ.current = q;
+      lastUrlQ.current = q;
+      lastCommittedQ.current = q;
     }
   }, [searchParams]);
 
@@ -45,7 +52,10 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
   const referrals = searchParams.get("referrals") === "true";
 
   const updateParams = useCallback(
-    (updates: { q?: string; skill?: string; referrals?: string }) => {
+    (
+      updates: { q?: string; skill?: string; referrals?: string },
+      navMethod: "push" | "replace" = "push"
+    ) => {
       const params = new URLSearchParams(searchParams.toString());
       if (updates.q !== undefined) {
         if (updates.q) params.set("q", updates.q);
@@ -59,7 +69,8 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
         if (updates.referrals === "true") params.set("referrals", "true");
         else params.delete("referrals");
       }
-      router.push(`/members${params.toString() ? `?${params.toString()}` : ""}`);
+      const url = `/members${params.toString() ? `?${params.toString()}` : ""}`;
+      router[navMethod](url, { scroll: false });
     },
     [router, searchParams]
   );
@@ -71,16 +82,51 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
     updateParamsRef.current = updateParams;
   }, [updateParams]);
 
+  // Debounced fire while typing: replace (no history entry per keystroke pause).
+  // Updates only lastUrlQ; lastCommittedQ stays reserved for push.
   const handleSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
       clearTimeout(debounceTimer.current);
       debounceTimer.current = setTimeout(() => {
-        lastPushedQ.current = value;
-        updateParamsRef.current({ q: value });
+        lastUrlQ.current = value;
+        updateParamsRef.current({ q: value }, "replace");
       }, SEARCH_DEBOUNCE_MS);
     },
     [] // stable — intentionally no deps; freshness comes from the ref
+  );
+
+  // Commit (blur / Enter): cancel pending debounce, then push to add history.
+  const commitSearch = useCallback(() => {
+    clearTimeout(debounceTimer.current);
+    const value = inputRef.current?.value ?? "";
+    if (value === lastCommittedQ.current) return;
+    lastCommittedQ.current = value;
+    lastUrlQ.current = value;
+    updateParamsRef.current({ q: value }, "push");
+  }, []);
+
+  // Skill / referrals changes capture the live input value so any in-progress
+  // typing isn't dropped by the stale searchParams snapshot.
+  const updateFilter = useCallback(
+    (updates: { skill?: string; referrals?: string }) => {
+      clearTimeout(debounceTimer.current);
+      const value = inputRef.current?.value ?? "";
+      lastCommittedQ.current = value;
+      lastUrlQ.current = value;
+      updateParamsRef.current({ ...updates, q: value }, "push");
+    },
+    []
+  );
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitSearch();
+      }
+    },
+    [commitSearch]
   );
 
   return (
@@ -94,13 +140,15 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
           placeholder="Search by name, role, or location..."
           defaultValue={searchParams.get("q") ?? ""}
           onChange={handleSearchChange}
+          onBlur={commitSearch}
+          onKeyDown={handleSearchKeyDown}
         />
       </div>
       <div className="space-y-2">
         <Label>Skill</Label>
         <Select
           value={skill || "all"}
-          onValueChange={(v) => updateParams({ skill: v === "all" ? "" : v })}
+          onValueChange={(v) => updateFilter({ skill: v === "all" ? "" : v })}
         >
           <SelectTrigger className="w-[180px]">
             <SelectValue placeholder="All skills" />
@@ -120,7 +168,7 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
           id="referrals"
           checked={referrals}
           onCheckedChange={(checked) =>
-            updateParams({ referrals: checked ? "true" : "" })
+            updateFilter({ referrals: checked ? "true" : "" })
           }
         />
         <Label

--- a/components/members/MemberFilters.tsx
+++ b/components/members/MemberFilters.tsx
@@ -27,6 +27,7 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
   const lastPushedQ = useRef(searchParams.get("q") ?? "");
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
+  // External navigation sync (back / forward only)
   useEffect(() => {
     const q = searchParams.get("q") ?? "";
     if (q !== lastPushedQ.current) {
@@ -34,6 +35,11 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
       lastPushedQ.current = q;
     }
   }, [searchParams]);
+
+  // Cancels any pending debounce timer when the component unmounts
+  useEffect(() => {
+    return () => clearTimeout(debounceTimer.current);
+  }, []);
 
   const skill = searchParams.get("skill") ?? "";
   const referrals = searchParams.get("referrals") === "true";
@@ -58,16 +64,23 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
     [router, searchParams]
   );
 
+  // Ref always pointing at the latest updateParams so the debounce timer
+  // callback never closes over a stale searchParams snapshot.
+  const updateParamsRef = useRef(updateParams);
+  useEffect(() => {
+    updateParamsRef.current = updateParams;
+  }, [updateParams]);
+
   const handleSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
       clearTimeout(debounceTimer.current);
       debounceTimer.current = setTimeout(() => {
         lastPushedQ.current = value;
-        updateParams({ q: value });
+        updateParamsRef.current({ q: value });
       }, SEARCH_DEBOUNCE_MS);
     },
-    [updateParams]
+    [] // stable — intentionally no deps; freshness comes from the ref
   );
 
   return (

--- a/components/members/__tests__/MemberFilters.test.tsx
+++ b/components/members/__tests__/MemberFilters.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import MemberFilters from "../MemberFilters";
+
+const pushMock = jest.fn();
+let currentSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => currentSearchParams,
+}));
+
+describe("MemberFilters", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    currentSearchParams = new URLSearchParams("q=al");
+  });
+
+  it("keeps in-progress search text when unrelated URL params change", () => {
+    const { rerender } = render(<MemberFilters allSkills={[]} />);
+
+    const search = screen.getByLabelText(/search/i);
+    fireEvent.change(search, { target: { value: "alice" } });
+
+    currentSearchParams = new URLSearchParams("q=al&skill=design");
+    rerender(<MemberFilters allSkills={[]} />);
+
+    expect(screen.getByLabelText(/search/i)).toHaveValue("alice");
+  });
+});

--- a/components/members/__tests__/MemberFilters.test.tsx
+++ b/components/members/__tests__/MemberFilters.test.tsx
@@ -1,18 +1,20 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 
 import MemberFilters from "../MemberFilters";
 
 const pushMock = jest.fn();
+const replaceMock = jest.fn();
 let currentSearchParams = new URLSearchParams();
 
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: pushMock }),
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
   useSearchParams: () => currentSearchParams,
 }));
 
 describe("MemberFilters", () => {
   beforeEach(() => {
     pushMock.mockReset();
+    replaceMock.mockReset();
     currentSearchParams = new URLSearchParams("q=al");
   });
 
@@ -26,5 +28,105 @@ describe("MemberFilters", () => {
     rerender(<MemberFilters allSkills={[]} />);
 
     expect(screen.getByLabelText(/search/i)).toHaveValue("alice");
+  });
+
+  it("commits on Enter via router.push", () => {
+    render(<MemberFilters allSkills={[]} />);
+
+    const search = screen.getByLabelText(/search/i);
+    fireEvent.change(search, { target: { value: "alice" } });
+    fireEvent.keyDown(search, { key: "Enter" });
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/members?q=alice",
+      expect.objectContaining({ scroll: false })
+    );
+  });
+
+  it("debounced typing navigates via router.replace, not push", () => {
+    jest.useFakeTimers();
+    try {
+      render(<MemberFilters allSkills={[]} />);
+
+      const search = screen.getByLabelText(/search/i);
+      fireEvent.change(search, { target: { value: "alice" } });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(replaceMock).toHaveBeenCalledWith(
+        "/members?q=alice",
+        expect.objectContaining({ scroll: false })
+      );
+      expect(pushMock).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("Enter after a debounce-replace still commits via router.push", () => {
+    jest.useFakeTimers();
+    try {
+      render(<MemberFilters allSkills={[]} />);
+
+      const search = screen.getByLabelText(/search/i);
+      fireEvent.change(search, { target: { value: "alice" } });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(replaceMock).toHaveBeenCalledTimes(1);
+      expect(pushMock).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(search, { key: "Enter" });
+
+      expect(pushMock).toHaveBeenCalledWith(
+        "/members?q=alice",
+        expect.objectContaining({ scroll: false })
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("Enter before debounce fires cancels the pending replace", () => {
+    jest.useFakeTimers();
+    try {
+      render(<MemberFilters allSkills={[]} />);
+
+      const search = screen.getByLabelText(/search/i);
+      fireEvent.change(search, { target: { value: "alice" } });
+      fireEvent.keyDown(search, { key: "Enter" });
+
+      expect(pushMock).toHaveBeenCalledWith(
+        "/members?q=alice",
+        expect.objectContaining({ scroll: false })
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(replaceMock).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("toggling referrals after typing preserves the in-progress q", () => {
+    render(<MemberFilters allSkills={[]} />);
+
+    const search = screen.getByLabelText(/search/i);
+    fireEvent.change(search, { target: { value: "alice" } });
+
+    const referrals = screen.getByLabelText(/open to mock interviews/i);
+    fireEvent.click(referrals);
+
+    expect(pushMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/members\?(?=.*q=alice)(?=.*referrals=true)/),
+      expect.objectContaining({ scroll: false })
+    );
   });
 });

--- a/e2e/members/search.spec.ts
+++ b/e2e/members/search.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, type Page } from "@playwright/test";
+
+import { loginWithPassword, requireE2ECredentials } from "../fixtures/auth";
+
+const SEARCH_DEBOUNCE_MS = 300;
+const DEBOUNCE_SETTLE_MS = SEARCH_DEBOUNCE_MS + 100;
+
+async function gotoMembers(page: Page) {
+  const creds = requireE2ECredentials("APPROVED_ONBOARDED");
+  await loginWithPassword(page, creds);
+  await page.goto("/members");
+  await expect(page.getByLabel(/search/i)).toBeVisible();
+}
+
+// Parked: URL-based assertions fail under Playwright because App Router's
+// pushState is silently skipped (vercel/next.js#83386, fixed upstream by
+// facebook/react#35839). The fix ships in Next.js 16.2.0+ via its bundled
+// React canary. This project is on Next 16.1.6 — unskip after the Next bump.
+test.describe.skip("Members search: debounce, history, and scroll behavior", () => {
+  test("debounced typing updates URL via replace (no new history entry)", async ({
+    page,
+  }) => {
+    await gotoMembers(page);
+    const search = page.getByLabel(/search/i);
+
+    await search.fill("alice");
+    await expect(page).toHaveURL(/[?&]q=alice(?:&|$)/);
+
+    // /members was replaced (not pushed) with /members?q=alice, so Back
+    // skips past it entirely to the prior page (dashboard).
+    await page.goBack();
+    await expect(page).not.toHaveURL(/\/members(?:\?|$)/);
+  });
+
+  test("Enter commits search via push (new history entry)", async ({ page }) => {
+    await gotoMembers(page);
+    const search = page.getByLabel(/search/i);
+
+    await search.fill("ali");
+    await expect(page).toHaveURL(/[?&]q=ali(?:&|$)/);
+
+    await search.fill("alice");
+    await search.press("Enter");
+    await expect(page).toHaveURL(/[?&]q=alice(?:&|$)/);
+
+    // Enter pushed a new entry, so Back returns to the prior (replaced)
+    // ?q=ali state — not all the way out of /members.
+    await page.goBack();
+    await expect(page).toHaveURL(/[?&]q=ali(?:&|$)/);
+  });
+
+  test("blur with a new value commits via push", async ({ page }) => {
+    await gotoMembers(page);
+    const search = page.getByLabel(/search/i);
+
+    await search.fill("alice");
+    // Tab out BEFORE debounce fires — commit handler must cancel the
+    // pending replace and push instead.
+    await search.press("Tab");
+    await expect(page).toHaveURL(/[?&]q=alice(?:&|$)/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/members(?!\?q)/);
+  });
+
+  test("blur with no change is a no-op (no duplicate history entry)", async ({
+    page,
+  }) => {
+    await gotoMembers(page);
+    const search = page.getByLabel(/search/i);
+
+    await search.fill("alice");
+    await expect(page).toHaveURL(/[?&]q=alice(?:&|$)/);
+
+    // Re-focus and blur without typing — commitSearch should short-circuit
+    // because value === lastPushedQ.
+    await search.click();
+    await search.press("Tab");
+    await page.waitForTimeout(DEBOUNCE_SETTLE_MS);
+
+    // If a duplicate push had occurred, Back would land on the prior
+    // /members?q=alice (replaced) entry — still on /members. With the
+    // no-op short-circuit, Back exits /members entirely.
+    await page.goBack();
+    await expect(page).not.toHaveURL(/\/members(?:\?|$)/);
+  });
+
+  test("input value does not cycle while typing (original bug)", async ({
+    page,
+  }) => {
+    await gotoMembers(page);
+    const search = page.getByLabel(/search/i);
+
+    await search.pressSequentially("alice", { delay: 50 });
+
+    // The input must show what was typed without being clobbered by any
+    // URL→state sync effect (the original feedback loop).
+    await expect(search).toHaveValue("alice");
+    await expect(page).toHaveURL(/[?&]q=alice(?:&|$)/);
+
+    // Stability check: value stays put after URL settles.
+    await page.waitForTimeout(DEBOUNCE_SETTLE_MS);
+    await expect(search).toHaveValue("alice");
+  });
+
+  test("filter toggle preserves scroll position", async ({ page }) => {
+    await gotoMembers(page);
+
+    const scrollableHeight = await page.evaluate(
+      () => document.documentElement.scrollHeight - window.innerHeight
+    );
+    test.skip(
+      scrollableHeight <= 0,
+      "Members list is not tall enough to scroll in this environment"
+    );
+
+    await page.evaluate(() => window.scrollTo(0, 200));
+    const scrollBefore = await page.evaluate(() => window.scrollY);
+    expect(scrollBefore).toBeGreaterThan(0);
+
+    const checkbox = page.getByLabel(/open to mock interviews/i);
+    await checkbox.click();
+    await expect(page).toHaveURL(/[?&]referrals=true(?:&|$)/);
+
+    const scrollAfter = await page.evaluate(() => window.scrollY);
+    expect(scrollAfter).toBe(scrollBefore);
+  });
+
+  test("browser back/forward syncs input value to URL", async ({ page }) => {
+    await gotoMembers(page);
+    const search = page.getByLabel(/search/i);
+
+    await search.fill("alice");
+    await search.press("Enter");
+    await expect(page).toHaveURL(/[?&]q=alice(?:&|$)/);
+
+    await search.fill("bob");
+    await search.press("Enter");
+    await expect(page).toHaveURL(/[?&]q=bob(?:&|$)/);
+    await expect(search).toHaveValue("bob");
+
+    await page.goBack();
+    await expect(page).toHaveURL(/[?&]q=alice(?:&|$)/);
+    await expect(search).toHaveValue("alice");
+
+    await page.goForward();
+    await expect(page).toHaveURL(/[?&]q=bob(?:&|$)/);
+    await expect(search).toHaveValue("bob");
+  });
+});


### PR DESCRIPTION
Closes https://github.com/What-We-Will/community-platform/issues/108. 

## Feedback loop resolution
Search input fields are ordinarily uncontrolled inputs unless there is any drop-down selection UI that populates while typing and can be selected to override the input field.  As the input field in this case is much simpler, we can afford to make it uncontrolled - we remove state management as this causes re-renders when changes occur, and replace with a ref to the input to mutate the DOM directly without React re-rendering.

## `useCallback` > `useEffect`
I also moved the debounce logic inside a `useCallback` event handler which is the pattern React docs recommend over effects. Both work but the former is less prone to unintentional calls due to the explicit attachment of the handler to the component.

## Tests!
So long as it's okay with @resolvicomai I'd like to incorporate their work particularly around tests included in https://github.com/What-We-Will/community-platform/pull/142. Merging the two PRs together in this way made the most sense to me!