### PR TITLE
Fix member search input sync

### DIFF
--- a/components/members/MemberFilters.tsx
+++ b/components/members/MemberFilters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -22,31 +22,21 @@ interface MemberFiltersProps {
 export default function MemberFilters({ allSkills }: MemberFiltersProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [searchInput, setSearchInput] = useState(
-    () => searchParams.get("q") ?? ""
-  );
-  const [debouncedSearch, setDebouncedSearch] = useState(
-    () => searchParams.get("q") ?? ""
-  );
+  const queryParam = searchParams.get("q") ?? "";
+  const lastPushedQueryRef = useRef(queryParam);
+  const [searchInput, setSearchInput] = useState(() => queryParam);
 
-  // Sync local state when URL changes (e.g. browser back/forward)
+  // Sync local state only when the q param changes externally (e.g. browser back/forward).
   useEffect(() => {
-    const q = searchParams.get("q") ?? "";
+    if (queryParam === lastPushedQueryRef.current) {
+      return;
+    }
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSearchInput(q);
-    setDebouncedSearch(q);
-  }, [searchParams]);
+    setSearchInput(queryParam);
+  }, [queryParam]);
 
   const skill = searchParams.get("skill") ?? "";
   const referrals = searchParams.get("referrals") === "true";
-
-  // Debounce search input
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchInput);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
 
   const updateParams = useCallback(
     (updates: { q?: string; skill?: string; referrals?: string }) => {
@@ -68,13 +58,18 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
     [router, searchParams]
   );
 
-  // Sync URL when debounced search changes
+  // Debounce search input
   useEffect(() => {
-    const currentQ = searchParams.get("q") ?? "";
-    if (debouncedSearch !== currentQ) {
-      updateParams({ q: debouncedSearch });
-    }
-  }, [debouncedSearch, updateParams, searchParams]);
+    const timer = setTimeout(() => {
+      const currentQ = searchParams.get("q") ?? "";
+      if (searchInput === currentQ) {
+        return;
+      }
+      lastPushedQueryRef.current = searchInput;
+      updateParams({ q: searchInput });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [searchInput, searchParams, updateParams]);
 
   return (
     <div className="flex flex-col gap-4 sm:flex-row sm:items-end">

--- a/components/members/__tests__/MemberFilters.test.tsx
+++ b/components/members/__tests__/MemberFilters.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import MemberFilters from "../MemberFilters";
+
+const pushMock = jest.fn();
+let currentSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => currentSearchParams,
+}));
+
+describe("MemberFilters", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    currentSearchParams = new URLSearchParams("q=al");
+  });
+
+  it("keeps in-progress search text when unrelated URL params change", () => {
+    const { rerender } = render(<MemberFilters allSkills={[]} />);
+
+    const search = screen.getByLabelText(/search/i);
+    fireEvent.change(search, { target: { value: "alice" } });
+
+    currentSearchParams = new URLSearchParams("q=al&skill=design");
+    rerender(<MemberFilters allSkills={[]} />);
+
+    expect(screen.getByLabelText(/search/i)).toHaveValue("alice");
+  });
+});


### PR DESCRIPTION
## Summary
- keep the member search input stable while unrelated URL params change
- debounce URL updates directly from the current search text
- add a regression test for the search field being reset while typing

Fixes #108

## Validation
- `npm test -- MemberFilters.test.tsx --runInBand`
- `npm test -- --runInBand`
- `npm run lint`
- `npm audit signatures`

Note: `npm run lint` reports one existing warning in `components/landing/share-your-story-form.tsx` about `aria-invalid` on role `group`; no new lint errors were introduced.