### PR TITLE
feat: replace router.push with router.replace

### DIFF
--- a/components/members/MemberFilters.tsx
+++ b/components/members/MemberFilters.tsx
@@ -63,7 +63,7 @@ export default function MemberFilters({ allSkills }: MemberFiltersProps) {
         if (updates.referrals === "true") params.set("referrals", "true");
         else params.delete("referrals");
       }
-      router.push(`/members${params.toString() ? `?${params.toString()}` : ""}`);
+      router.replace(`/members${params.toString() ? `?${params.toString()}` : ""}`);
     },
     [router, searchParams]
   );


### PR DESCRIPTION
## `router.replace` > `router.push` (for search/filter inputs)
This is a proposal to exchange `router.push` for `router.replace` to provide a more typical back/forward navigation experience for users. Relevant Next.js docs: https://nextjs.org/docs/app/api-reference/functions/use-router

`router.push` records every change to the query params as a separate point in browser history and so you'd have to hit back through all the searches you performed to get to the previous major page. 

Whereas `router.replace` preserves the last input value if you navigated away from the page, but none of the intermediary search values.

---

Note: I do not mind which direction we go - just wanted to document the proposal and get input for future reference!