### PR TITLE
Feature/deploy resilience

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -139,20 +139,26 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
           PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        # Non-fatal: a Slack hiccup must never flip a good deploy to failed.
+        # jq builds the JSON so values are escaped regardless of content.
         run: |
-          curl -X POST -H 'Content-type: application/json' \
-            --data "{\"text\":\"PR #${PR_NUMBER} preview deployed: ${PREVIEW_URL}\"}" \
-            "$SLACK_WEBHOOK_URL"
+          payload="$(jq -cn --arg text "PR #${PR_NUMBER} preview deployed: ${PREVIEW_URL}" '{text: $text}')"
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --max-time 10 --retry 2 --retry-delay 2 \
+            --data "$payload" "$SLACK_WEBHOOK_URL" || true
 
       - name: Slack notify failure
         if: failure()
         env:
           PR_NUMBER: ${{ github.event.number }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        # Non-fatal: never let a Slack hiccup drop the failure alert silently.
+        # jq builds the JSON so values are escaped regardless of content.
         run: |
-          curl -X POST -H 'Content-type: application/json' \
-            --data "{\"text\":\"❌ PR #${PR_NUMBER} preview failed.\"}" \
-            "$SLACK_WEBHOOK_URL"
+          payload="$(jq -cn --arg text "❌ PR #${PR_NUMBER} preview failed." '{text: $text}')"
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --max-time 10 --retry 2 --retry-delay 2 \
+            --data "$payload" "$SLACK_WEBHOOK_URL" || true
 
   security-scan:
     if: github.event.action != 'closed'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Slack notify success
         if: success()
         env:
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -151,7 +151,7 @@ jobs:
       - name: Slack notify failure
         if: failure()
         env:
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         # Non-fatal: never let a Slack hiccup drop the failure alert silently.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -137,12 +137,13 @@ jobs:
         if: success()
         env:
           PR_NUMBER: ${{ github.event.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
           PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         # Non-fatal: a Slack hiccup must never flip a good deploy to failed.
         # jq builds the JSON so values are escaped regardless of content.
         run: |
-          payload="$(jq -cn --arg text "PR #${PR_NUMBER} preview deployed: ${PREVIEW_URL}" '{text: $text}')"
+          payload="$(jq -cn --arg text "✅ <${PR_URL}|PR #${PR_NUMBER}> preview deployed: ${PREVIEW_URL}" '{text: $text}')"
           curl -sS -X POST -H 'Content-type: application/json' \
             --max-time 10 --retry 2 --retry-delay 2 \
             --data "$payload" "$SLACK_WEBHOOK_URL" || true
@@ -151,11 +152,12 @@ jobs:
         if: failure()
         env:
           PR_NUMBER: ${{ github.event.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         # Non-fatal: never let a Slack hiccup drop the failure alert silently.
         # jq builds the JSON so values are escaped regardless of content.
         run: |
-          payload="$(jq -cn --arg text "❌ PR #${PR_NUMBER} preview failed." '{text: $text}')"
+          payload="$(jq -cn --arg text "❌ <${PR_URL}|PR #${PR_NUMBER}> preview failed." '{text: $text}')"
           curl -sS -X POST -H 'Content-type: application/json' \
             --max-time 10 --retry 2 --retry-delay 2 \
             --data "$payload" "$SLACK_WEBHOOK_URL" || true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -108,9 +108,7 @@ jobs:
           SUPABASE_URL: ${{ secrets.PREVIEW_SUPABASE_URL_BASE }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PREVIEW_SUPABASE_URL_BASE }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PREVIEW_SUPABASE_PUB_KEY }}
-        run: |
-          url=$(vercel deploy --prebuilt)
-          echo "preview_url=$url" >> $GITHUB_OUTPUT
+        run: bash scripts/ci/vercel-deploy-with-retry.sh preview_url --prebuilt
 
       - name: Comment PR with URL
         if: github.event_name == 'pull_request'

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -58,9 +58,7 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          url=$(vercel deploy --prebuilt --prod)
-          echo "production_url=$url" >> $GITHUB_OUTPUT
+        run: bash scripts/ci/vercel-deploy-with-retry.sh production_url --prebuilt --prod
 
       - name: Comment PR with URL
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -71,7 +71,9 @@ jobs:
               core.warning('production_url is empty — skipping PR comment');
               return;
             }
-            if (!/^https:\/\/[a-z0-9.-]+\.vercel\.app\b/.test(url)) {
+            // Scheme-only check: prod may resolve to a custom domain, not *.vercel.app.
+            // The deploy script already rejects non-https output before it reaches here.
+            if (!/^https:\/\//.test(url)) {
               core.setFailed(`Unexpected production URL: ${url}`);
               return;
             }

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -92,3 +92,17 @@ jobs:
                 body: `✅ Production deployed: ${url}`,
               });
             }
+
+      - name: Slack notify failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        # Non-fatal: never let a Slack hiccup mask the deploy result.
+        # jq builds the JSON so values are escaped regardless of content.
+        run: |
+          payload="$(jq -cn --arg text "❌ PRODUCTION deploy failed for ${COMMIT_SHA}. Run: ${RUN_URL}" '{text: $text}')"
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --max-time 10 --retry 2 --retry-delay 2 \
+            --data "$payload" "$SLACK_WEBHOOK_URL" || true

--- a/TESTING_STANDARDS.preamble.md
+++ b/TESTING_STANDARDS.preamble.md
@@ -2,7 +2,7 @@
 
 Loaded in every testing-related session. All rules below apply regardless of task type.
 
-**Last updated:** 2026-06-04 · **Applies to:** Vitest 4 · **Owner:** platform lead
+**Last updated:** 2026-06-21 · **Applies to:** Vitest 4 · **Owner:** platform lead
 
 ---
 
@@ -14,7 +14,7 @@ Loaded in every testing-related session. All rules below apply regardless of tas
 
 3. **Litmus test.** If a refactor changes zero behavior but breaks a test, the test was wrong.
 
-4. **Mock boundaries only.** Never mock internal functions or utilities from `lib/utils/`. Mock only: Supabase client, `next/headers`, `next/cache`, `next/navigation`, `fetch`, and environment variables.
+4. **Mock boundaries only.** Never mock internal functions or utilities from `lib/utils/`. Mock only: Supabase client, `next/headers`, `next/cache`, `next/navigation`, `fetch`, the `nodemailer` transport, and environment variables. The `nodemailer` transport is a network (SMTP) boundary like `fetch`; mock it and assert on the outbound email envelope (the observable side effect), never on internal call order.
 
 5. **Use factory functions.** All test data comes from `lib/__tests__/factories.ts`. Never construct test objects inline.
 

--- a/app/api/bug-report/route.test.ts
+++ b/app/api/bug-report/route.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression guard for the nodemailer transport contract. The route's
+ * observable side effect is the outbound admin email, so we mock the SMTP
+ * boundary (analogous to fetch) and assert on the envelope it receives — not
+ * on internal call order. This pins the createTransport/sendMail interface so a
+ * future nodemailer bump that changes how we must call it fails here loudly.
+ */
+
+// Hoisted so the vi.mock factory can close over the same spies the tests assert on.
+const { createTransport, sendMail } = vi.hoisted(() => {
+  const sendMail = vi.fn();
+  return { createTransport: vi.fn(() => ({ sendMail })), sendMail };
+});
+
+vi.mock("nodemailer", () => ({ default: { createTransport } }));
+
+const VALID_ENV = {
+  GMAIL_USER: "bot@example.com",
+  GMAIL_APP_PASSWORD: "app-pass-123",
+  ADMIN_EMAIL: "admin@example.com",
+} as const;
+
+function stubEnv(env: Record<string, string>) {
+  for (const [key, value] of Object.entries(env)) vi.stubEnv(key, value);
+}
+
+function makeRequest(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  return new Request("https://app.example.com/api/bug-report", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+// The route reads env at module load, so re-import after stubbing to pick it up.
+async function loadPost() {
+  vi.resetModules();
+  return (await import("./route")).POST;
+}
+
+const validReport = {
+  email: "reporter@example.com",
+  description: "The save button does nothing",
+  steps: "1. open profile  2. click save",
+};
+
+describe("POST /api/bug-report — emails the admin a submitted bug report", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    stubEnv(VALID_ENV);
+  });
+
+  it("should send the report to the admin address and return success when input is valid", async () => {
+    const post = await loadPost();
+
+    const response = await post(
+      makeRequest(validReport, { referer: "https://app.example.com/profile" }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    const mail = sendMail.mock.calls[0][0];
+    expect(mail).toMatchObject({
+      to: "admin@example.com",
+      from: expect.stringContaining("bot@example.com"),
+      replyTo: "reporter@example.com",
+      subject: expect.stringContaining("reporter@example.com"),
+    });
+    expect(mail.html).toContain("The save button does nothing");
+    expect(mail.html).toContain("1. open profile");
+    expect(mail.html).toContain("https://app.example.com/profile");
+  });
+
+  it("should configure the transport with the gmail service and app-password credentials", async () => {
+    const post = await loadPost();
+
+    await post(makeRequest(validReport));
+
+    expect(createTransport).toHaveBeenCalledWith({
+      service: "gmail",
+      auth: { user: "bot@example.com", pass: "app-pass-123" },
+    });
+  });
+
+  it("should omit the steps section from the email when no steps are provided", async () => {
+    const post = await loadPost();
+
+    await post(makeRequest({ email: validReport.email, description: validReport.description }));
+
+    const mail = sendMail.mock.calls[0][0];
+    expect(mail.html).not.toContain("Steps to Reproduce");
+  });
+
+  it("should fall back to an unknown page label when the referer header is absent", async () => {
+    const post = await loadPost();
+
+    await post(makeRequest(validReport));
+
+    expect(sendMail.mock.calls[0][0].html).toContain("unknown");
+  });
+
+  it("should return 400 and send nothing when the description is missing", async () => {
+    const post = await loadPost();
+
+    const response = await post(makeRequest({ email: validReport.email }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Description is required." });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 and send nothing when the reporter email is missing", async () => {
+    const post = await loadPost();
+
+    const response = await post(makeRequest({ description: validReport.description }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Email is required." });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("should return 503 and send nothing when SMTP credentials are not configured", async () => {
+    stubEnv({ GMAIL_USER: "", GMAIL_APP_PASSWORD: "", ADMIN_EMAIL: "" });
+    const post = await loadPost();
+
+    const response = await post(makeRequest(validReport));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Bug reporting is not configured on this server.",
+    });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("should return 500 when the mail transport rejects", async () => {
+    sendMail.mockRejectedValueOnce(new Error("SMTP unavailable"));
+    const post = await loadPost();
+
+    const response = await post(makeRequest(validReport));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Something went wrong." });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,13 +150,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -175,21 +175,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -206,14 +206,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -236,14 +236,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -299,29 +299,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -406,9 +406,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -416,14 +416,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -545,33 +545,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1876,19 +1876,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -4149,6 +4136,118 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/cli-darwin-arm64": {
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.106.0.tgz",
+      "integrity": "sha512-xi/IAjjbebh6xA9Nkkb7ZwC5ACKJ38OqMoYk1y20ScW5Wt+pxTCcOcaWDWu+2u2Pwc3vTYnXhbknVcQt9UcChQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@supabase/cli-darwin-x64": {
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-x64/-/cli-darwin-x64-2.106.0.tgz",
+      "integrity": "sha512-AT2s/8/3Ffb7IkcUXK6sA/iPCzJhh4Fh/XqzAGNGsVd1xCA/ZGniqU8BL03TqPkN1sR0iDaShjMLLIlHEflyPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-arm64": {
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64/-/cli-linux-arm64-2.106.0.tgz",
+      "integrity": "sha512-L/pX7fkV31x7zPrUOcD6KMtZ03j16o41XxgkACFoOAE9lFz8KaJOBSHvn2QLeWEa2kLz7jwpisvpshPSMjuxOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-arm64-musl": {
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.106.0.tgz",
+      "integrity": "sha512-2LExuOHuU6odXorNTvq4M/OvueW+wOs3KDsaCpk+scQMnB6LbmqNidEjXAsKpZu3zyE8MmmtdbJBlRNN/KLdcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-x64": {
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64/-/cli-linux-x64-2.106.0.tgz",
+      "integrity": "sha512-+ihtqFNURc8ssULgQoHQBR4AtUmxez9dtqjclqOV0y5r65SX7Ginmiby4XDW9LPlqHT+MB7OyD1vk0T6pQUtPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-x64-musl": {
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64-musl/-/cli-linux-x64-musl-2.106.0.tgz",
+      "integrity": "sha512-wz7heB3wwzmRdLRgqngd2VjPPNIdv6/Y8Q0dX/ZvjcL9/Nk8BYSZ7yjypapLpra+swRnbEJ4jAU6eAShiaB1Hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-windows-arm64": {
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-arm64/-/cli-windows-arm64-2.106.0.tgz",
+      "integrity": "sha512-QkEfRDiuuQwcfASo2DIJZ59AFV6xpqhPNo4r0kSVt38StYk3iL7ZcSOkZvGQWLlJ8kXKPBWEMhLnfHQF9r+Xfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@supabase/cli-windows-x64": {
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-x64/-/cli-windows-x64-2.106.0.tgz",
+      "integrity": "sha512-1tQFbrH1KJhWJqHrY087XPz1WRi20eKG1pebG+6PjSD6XN+j0+x1PTOtBZrylXgY1fOg8BqgU8kl3KX8hI5l9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@supabase/functions-js": {
       "version": "2.98.0",
       "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.98.0.tgz",
@@ -6348,23 +6447,6 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/bin-links": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
-      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^8.0.0",
-        "npm-normalize-package-bin": "^5.0.0",
-        "proc-log": "^6.0.0",
-        "read-cmd-shim": "^6.0.0",
-        "write-file-atomic": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -6631,16 +6713,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -6817,16 +6889,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cmd-shim": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
-      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/cmdk": {
@@ -9070,9 +9132,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10028,10 +10090,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11906,29 +11978,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -12170,22 +12219,12 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.11.tgz",
+      "integrity": "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/npm-normalize-package-bin": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
-      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -12885,16 +12924,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -12966,9 +12995,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -13259,16 +13288,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/read-cmd-shim": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
-      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/recast": {
@@ -14521,47 +14540,23 @@
       }
     },
     "node_modules/supabase": {
-      "version": "2.92.1",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.92.1.tgz",
-      "integrity": "sha512-BB3olR2glhrE0YGDhq0vknJdrwjROaIHgiC/OZc94eLbBHnsJ3szKeRZkcF9dxRgxuq6QWdxCrn5m14lfu9tug==",
+      "version": "2.106.0",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.106.0.tgz",
+      "integrity": "sha512-jV0PJi5LqXUMZ4kriRLvST3DX1YDhrxOgnFJLOn6oUw3KQEFJPXhA60yLQ9aWG1E1uZCp4vUJwSuSGq3HPfaSQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "bin-links": "^6.0.0",
-        "https-proxy-agent": "^9.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "7.5.13"
-      },
       "bin": {
-        "supabase": "bin/supabase"
+        "supabase": "dist/supabase.js"
       },
-      "engines": {
-        "npm": ">=8"
-      }
-    },
-    "node_modules/supabase/node_modules/agent-base": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/supabase/node_modules/https-proxy-agent": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
-      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 20"
+      "optionalDependencies": {
+        "@supabase/cli-darwin-arm64": "2.106.0",
+        "@supabase/cli-darwin-x64": "2.106.0",
+        "@supabase/cli-linux-arm64": "2.106.0",
+        "@supabase/cli-linux-arm64-musl": "2.106.0",
+        "@supabase/cli-linux-x64": "2.106.0",
+        "@supabase/cli-linux-x64-musl": "2.106.0",
+        "@supabase/cli-windows-arm64": "2.106.0",
+        "@supabase/cli-windows-x64": "2.106.0"
       }
     },
     "node_modules/supports-color": {
@@ -14639,33 +14634,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/tiny-invariant": {
@@ -16125,23 +16093,10 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/write-file-atomic": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
-      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.575.0",
         "next": "16.2.6",
-        "nodemailer": "^8.0.1",
+        "nodemailer": "^9.0.1",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-day-picker": "^9.14.0",
@@ -12219,9 +12219,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.11.tgz",
-      "integrity": "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -15053,9 +15053,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
-      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.575.0",
     "next": "16.2.6",
-    "nodemailer": "^8.0.1",
+    "nodemailer": "^9.0.1",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-day-picker": "^9.14.0",
@@ -68,5 +68,8 @@
     "**/*.{ts,tsx}": [
       "eslint --fix"
     ]
+  },
+  "overrides": {
+    "undici": "^7.28.0"
   }
 }

--- a/scripts/ci/vercel-deploy-with-retry.sh
+++ b/scripts/ci/vercel-deploy-with-retry.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Runs `vercel deploy` with a bounded retry to ride out transient Vercel platform
+# errors (e.g. a server-side 500 after the bundle has fully uploaded). Captures the
+# deployment URL into $GITHUB_OUTPUT on success, and still exits non-zero after the
+# attempts are exhausted so genuine failures are never masked.
+#
+# Usage: vercel-deploy-with-retry.sh <output_key> [vercel deploy args...]
+#   <output_key>  written to $GITHUB_OUTPUT as "<output_key>=<url>" on success
+#
+# Examples:
+#   bash scripts/ci/vercel-deploy-with-retry.sh preview_url --prebuilt
+#   bash scripts/ci/vercel-deploy-with-retry.sh production_url --prebuilt --prod
+#
+# Tunables (env): DEPLOY_RETRY_ATTEMPTS (default 3), DEPLOY_RETRY_BASE_DELAY (default 5s).
+set -euo pipefail
+
+output_key="$1"
+shift
+
+attempts="${DEPLOY_RETRY_ATTEMPTS:-3}"
+base_delay="${DEPLOY_RETRY_BASE_DELAY:-5}"
+
+# Guard the tunables: a non-numeric or zero attempt count would make `seq 1 0`
+# emit nothing, silently skipping every deploy and exiting 1 with no attempt made.
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+  echo "::error::DEPLOY_RETRY_ATTEMPTS must be a positive integer (got: ${attempts})" >&2
+  exit 1
+fi
+
+for i in $(seq 1 "$attempts"); do
+  # The deploy runs in the `if` condition, so errexit is suspended for it: a failed
+  # attempt is handled by the loop instead of aborting the script. Command
+  # substitution captures only stdout; CLI progress/errors flow to the log.
+  if out="$(vercel deploy "$@")"; then
+    # Take only the last stdout line and strip CR, then require it to be a URL
+    # before writing to $GITHUB_OUTPUT. This prevents stray CLI output (multiple
+    # lines, advisory text) from injecting extra `key=value` pairs into the
+    # output file, which a downstream step could otherwise consume.
+    url="$(printf '%s' "$out" | tail -n1 | tr -d '\r')"
+    if [[ ! "$url" =~ ^https:// ]]; then
+      echo "::error::Unexpected deploy output (no https URL on last line): ${out}" >&2
+      exit 1
+    fi
+    echo "${output_key}=${url}" >> "$GITHUB_OUTPUT"
+    echo "Deploy succeeded on attempt ${i}/${attempts}: ${url}"
+    exit 0
+  fi
+  echo "::warning::vercel deploy attempt ${i}/${attempts} failed."
+  # Incremental backoff; skip the wait after the final attempt.
+  if [ "$i" -lt "$attempts" ]; then
+    sleep "$((base_delay * i))"
+  fi
+done
+
+echo "::error::vercel deploy failed after ${attempts} attempts." >&2
+exit 1

--- a/scripts/ci/vercel-deploy-with-retry.sh
+++ b/scripts/ci/vercel-deploy-with-retry.sh
@@ -27,6 +27,13 @@ if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
   exit 1
 fi
 
+# base_delay feeds shell arithmetic in the backoff `sleep` below; guard it the same
+# way so a non-numeric value fails fast and clearly instead of mid-retry-loop.
+if ! [[ "$base_delay" =~ ^[0-9]+$ ]] || [ "$base_delay" -lt 1 ]; then
+  echo "::error::DEPLOY_RETRY_BASE_DELAY must be a positive integer (got: ${base_delay})" >&2
+  exit 1
+fi
+
 for i in $(seq 1 "$attempts"); do
   # The deploy runs in the `if` condition, so errexit is suspended for it: a failed
   # attempt is handled by the loop instead of aborting the script. Command


### PR DESCRIPTION
## Summary

  Hardens the Vercel deploy path against transient platform failures and closes a
  production alerting gap. Two related changes under one deploy-resilience theme,
  one commit per issue:

  - **`3637089` — Closes #151:** retry transient `vercel deploy` failures (preview + production)
  - **`d0b915d` — Closes #152:** alert on production deploy failure; harden preview Slack notices

  ## What changed

  ### Retry (#151)
  - New `scripts/ci/vercel-deploy-with-retry.sh`: a bounded retry (3 attempts,
    incremental backoff) around `vercel deploy`, shared by both deploy jobs.
  - The deploy URL is taken from the last stdout line and validated as an `https`
    URL before being written to `GITHUB_OUTPUT`.
  - The job still exits non-zero after attempts are exhausted — genuine failures
    are not masked — and a first-attempt success creates no extra deployments.
  - Wired into the deploy step of both `preview.yml` and `production.yml`.

  ### Notifications (#152)
  - `production.yml`: new non-fatal `if: failure()` Slack alert carrying the commit
    SHA and run URL, reusing the existing `SLACK_WEBHOOK_URL` secret. A failed
    production deploy previously alerted nobody.
  - `preview.yml`: hardened the two existing Slack notify steps — bounded
    `--max-time`/`--retry`, made non-fatal (`|| true`), and built the JSON payload
    with `jq` so values are escaped regardless of content.

  ## Why

  PR #150 hit a transient Vercel `Internal Server Error` *after* a full bundle
  upload — a server-side 500, not a build problem — which failed an otherwise-valid
  deploy. On production that flake blocks a release behind branch protection. The
  retry rides out transient platform errors without masking real ones; the
  production alert ensures a broken release surfaces immediately.

  ## Security

  Reviewed by a GitHub Actions security pass. Findings introduced by this change
  were fixed in-branch:
  - `GITHUB_OUTPUT` injection — output now validated as an `https` URL and reduced
    to a single line before write.
  - Slack JSON built by string interpolation — replaced with `jq --arg` escaping.
  - Unvalidated retry tunables — guarded (`DEPLOY_RETRY_ATTEMPTS` must be a positive
    integer).

  All dynamic values are passed via `env:` (no `${{ }}` interpolation into `run:`
  shells), and existing SHA-pinning and the preview `pull_request` (not `_target`)
  trigger are unchanged.

  Two pre-existing findings are **out of scope** and tracked separately:
  - Least-privilege `GITHUB_TOKEN` scoping on deploy jobs → #153
  - Fork-PR lint/test config execution → tracked on the #139 CI-hardening checklist

  ## Migration notes

  None — no schema, RLS, or data changes.

  ## Testing

  - `scripts/ci/vercel-deploy-with-retry.sh` exercised against a stubbed `vercel`:
    first-try success, transient-flake-then-success, total failure (exits non-zero,
    no output written), junk non-URL output (rejected), and bad tunable (fails fast).
  - `shellcheck` clean; both workflows parse as YAML.
  - Note: the production failure-notify step only fires on a real `workflow_dispatch`
    deploy; the preview workflow exercises the shared retry script on this PR.