### PR TITLE
Fix profile navigation from user avatar

### DIFF
--- a/app/(app)/app-shell.tsx
+++ b/app/(app)/app-shell.tsx
@@ -253,7 +253,7 @@ export default function AppShell({ children, user }: AppShellProps) {
           </nav>
 
           <div className="sticky bottom-0 z-30 border-t bg-background p-4">
-            <div className="flex items-center gap-3 rounded-lg px-3 py-2">
+            <Link href="/profile" className="flex items-center gap-3 rounded-lg px-3 py-2">
               <UserAvatar
                 avatarUrl={user.avatarUrl}
                 displayName={user.displayName}
@@ -267,7 +267,7 @@ export default function AppShell({ children, user }: AppShellProps) {
                   {user.email}
                 </p>
               </div>
-            </div>
+            </Link>
             <Separator className="my-3" />
             <div className="px-3 pb-1">
               <BugReportDialog reporterEmail={user.email} />


### PR DESCRIPTION
## What changed
- Wrapped the sidebar user avatar/details card in a Link component
- Clicking the user card now navigates to /profile

## Bug
Users could click the personal avatar area but nothing happened.