### PR TITLE
PR 114 - Personal icon links nowhere — wrap in `<Link>`

### DIFF
--- a/app/(app)/app-shell.tsx
+++ b/app/(app)/app-shell.tsx
@@ -253,21 +253,25 @@ export default function AppShell({ children, user }: AppShellProps) {
           </nav>
 
           <div className="sticky bottom-0 z-30 border-t bg-background p-4">
-            <div className="flex items-center gap-3 rounded-lg px-3 py-2">
+            <Link
+              href="/profile"
+              onClick={() => setSidebarOpen(false)}
+              className="flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-accent group"
+            >
               <UserAvatar
                 avatarUrl={user.avatarUrl}
                 displayName={user.displayName}
                 size="md"
               />
               <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium">
+                <p className="truncate text-sm font-medium group-hover:underline">
                   {user.displayName}
                 </p>
                 <p className="truncate text-xs text-muted-foreground">
                   {user.email}
                 </p>
               </div>
-            </div>
+            </Link>
             <Separator className="my-3" />
             <div className="px-3 pb-1">
               <BugReportDialog reporterEmail={user.email} />


### PR DESCRIPTION
## TLDR

The personal avatar/name block at the bottom of the sidebar did not navigate anywhere when clicked. This wraps it in a `<Link>` to `/profile`.

## Changes
* Wrapped the sidebar user avatar and name block in `<Link href="/profile">`
* Added hover styles `(hover:bg-accent, group-hover:underline on name)`
* Closes mobile sidebar on click (same as other nav links)

## Testing
When you click the sidebar footer, display name or email area --> check that it navigates to `/profile`.
