### PR TITLE
PR 114 - Increase Avatar upload limit from 2MB to 10 MB

### DIFF
--- a/components/profile/AvatarUpload.tsx
+++ b/components/profile/AvatarUpload.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { getAvatarColor, getInitials } from "@/lib/utils/avatar";
 import { uploadPublicFile, validateFile } from "@/lib/storage";
 
-const AVATAR_LIMIT_MB = 2;
+const AVATAR_LIMIT_MB = 10;
 const AVATAR_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"];
 
 interface AvatarUploadProps {


### PR DESCRIPTION
## TLDR
Pretty self-explanatory here.

Profile avatar uploads were capped too low and likely rejected many phone photos.

## Question
Is 10 MB enough? Or should we go for a higher cap? 