### PR TITLE
chore(dependabot): enable version updates with grouped config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,134 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      # --- Version-locked families (NO update-types filter: a major stays atomic) ---
+      # First match wins, so every family must sit ABOVE the catch-alls below.
+      react:
+        # @types/react* track react's version, not their own cadence
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      next:
+        # eslint-config-next tracks next's version, not eslint's
+        patterns:
+          - "next"
+          - "eslint-config-next"
+      vitest:
+        # @vitest/coverage-v8 is lockstep with vitest's version
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      date-fns:
+        # date-fns-tz tracks date-fns' major
+        patterns:
+          - "date-fns"
+          - "date-fns-tz"
+      radix-ui:
+        patterns:
+          - "@radix-ui/*"
+          - "radix-ui"
+      dnd-kit:
+        patterns:
+          - "@dnd-kit/*"
+      supabase:
+        patterns:
+          - "@supabase/*"
+          - "supabase"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "tailwind-merge"
+          - "tw-animate-css"
+      # --- Category groups ---
+      testing:
+        # not version-locked to each other; majors come as individual reviewable PRs
+        patterns:
+          - "@playwright/*"
+          - "@testing-library/*"
+          - "playwright"
+        update-types:
+          - minor
+          - patch
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+      types:
+        patterns:
+          - "@types/*"
+        exclude-patterns:
+          - "@types/react"
+          - "@types/react-dom"
+      # --- Catch-alls (dependency-type only; must stay LAST) ---
+      dev-minor-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      prod-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: next
+        update-types:
+          - version-update:semver-major
+      - dependency-name: eslint-config-next
+        update-types:
+          - version-update:semver-major
+      - dependency-name: react
+        update-types:
+          - version-update:semver-major
+      - dependency-name: react-dom
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@types/react"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@types/react-dom"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@supabase/supabase-js"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@supabase/ssr"
+        update-types:
+          - version-update:semver-major
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,9 +48,13 @@ updates:
         patterns:
           - "@dnd-kit/*"
       supabase:
+        # Runtime client stack — supabase-js + ssr move together for SSR auth.
+        # The `supabase` CLI is intentionally NOT grouped here: it's a dev tool on
+        # its own release track (github.com/supabase/cli), unrelated to the SDK's
+        # versioning. It flows through dev-minor-patch; majors come as individual
+        # reviewable PRs (we stay current on the CLI rather than holding majors).
         patterns:
           - "@supabase/*"
-          - "supabase"
       tailwind:
         patterns:
           - "tailwindcss"


### PR DESCRIPTION
## Why
There was no dependabot.yml on the default branch, so version updates never ran — the repo only received dependency PRs when a security advisory triggered a one-off fix.

Committing this config to the default branch to enable it.  Note that alerts and security updates were already enabled.


## Grouping design

- **Version-locked families** (no `update-types` filter, so a major stays atomic): `react` (+`@types/react*`), `next` (+`eslint-config-next`), `vitest` (+`@vitest/*`), `date-fns` (+`date-fns-tz`),
`radix-ui`, `dnd-kit`, `supabase`, `tailwind`.
- `eslint-config-next` is grouped with `next` (it tracks next's version, not eslint's); `@types/react*` are grouped with `react` and excluded from the generic `types` group (they track the react
runtime).
- **Ignore list** covers majors for `eslint-config-next`, `@types/react`, `@types/react-dom` in addition to next/react/react-dom/supabase, so a companion package can't drift ahead of its ignored runtime.
- **Catch-alls** (`dev-minor-patch`, `prod-minor-patch`) ordered last to batch the long tail; unrelated majors stay as individual reviewable PRs.
- `github-actions` updates grouped under a single PR.

Group order validated with `check-group-order.py` (exit 0 — every family precedes the catch-alls).

## Security implications

None to the application. This is CI/dependency-management config only — no runtime code, no RLS, no schema changes. It increases security posture by surfacing routine upstream patches that previously went unproposed.

## Migration notes

None. YAML-only change.

## Rollout

First scheduled run is **Monday**; expect a burst of grouped PRs up to the open-PR limit (5 npm / 3 actions). This is expected and acceptable.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)