### PR TITLE
Update platform Slack link to WWW workspace

### DIFF
--- a/app/(app)/app-shell.tsx
+++ b/app/(app)/app-shell.tsx
@@ -214,14 +214,14 @@ export default function AppShell({ children, user }: AppShellProps) {
               </Link>
             ))}
             <a
-              href="https://techworkersco.slack.com"
+              href="https://join.slack.com/t/whatwewill/shared_invite/zt-3zxh2f0x0-~zvous3lLva6Pi8IJQ0T8A"
               target="_blank"
               rel="noopener noreferrer"
               onClick={() => setSidebarOpen(false)}
               className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
             >
               <ExternalLink className="size-5 shrink-0" />
-              TWC Slack
+              Join Slack
             </a>
 
             <Separator className="my-2" />


### PR DESCRIPTION
### Description

Updated the sidebar Slack link so members are directed to the What We Will (WWW) Slack workspace instead of the Tech Workers Coalition (TWC) Slack.

### Changes

* Renamed link label from "TWC Slack" to "Join Slack"
* Pointed to the WWW Slack invite URL: https://join.slack.com/t/whatwewill/shared_invite/zt-3zxh2f0x0-~zvous3lLva6Pi8IJQ0T8A

#### Related issue: [What-We-Will/community-platform#171 — Change Platform Slack link from TWC to WWW Slack](https://github.com/What-We-Will/community-platform/issues/171)

### Testing
 - [ ] Open the platform sidebar and confirm the link reads "Join Slack"
 - [ ] Click the link and verify it opens the WWW Slack invite in a new tab