### PR TITLE
On local, allow engineers to create new users as Admin role without need for approval to platform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ SUPABASE_SERVICE_ROLE_KEY=
 
 # ── App ───────────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+# Local dev only — auto-approve and grant admin on first onboarding
+LOCAL_DEV_AUTO_ADMIN=true
 
 # ── Email (Nodemailer / Gmail) ────────────────────────────────────────────────
 GMAIL_USER=

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Open [http://localhost:3000](http://localhost:3000). Sign up via the auth flow;
 
 To manually approve yourself, open Supabase > Table Editor > "profiles". You should see a row for your user. Change the "approval_status" column from "pending" to "approved".
 
+For local volunteer setup, add `LOCAL_DEV_AUTO_ADMIN=true` to `.env.local` to skip manual approval and grant admin on first onboarding.
+
 After onboarding you’ll see the main app (dashboard, events, groups, messages, members, profile).
 
 

--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -34,6 +34,8 @@ export async function completeOnboarding(
     return { error: "LinkedIn URL is required to verify your background." };
   }
 
+  const localDevAutoAdmin = process.env.LOCAL_DEV_AUTO_ADMIN === "true";
+
   const { error } = await supabase.from("profiles").upsert(
     {
       id: user.id,
@@ -47,7 +49,9 @@ export async function completeOnboarding(
       linkedin_url: data.linkedin_url || null,
       timezone: safeTimezone(data.timezone),
       is_onboarded: true,
-      approval_status: "pending",
+      ...(localDevAutoAdmin
+        ? { approval_status: "approved" as const, role: "admin" as const }
+        : { approval_status: "pending" as const }),
     },
     { onConflict: "id" }
   );
@@ -56,12 +60,14 @@ export async function completeOnboarding(
     return { error: error.message };
   }
 
-  // Notify admin that a new account needs review
-  await notifyAdminOfNewApplication({
-    displayName: data.display_name,
-    linkedinUrl: data.linkedin_url,
-    userEmail: user.email ?? "unknown",
-  });
+  if (!localDevAutoAdmin) {
+    // Notify admin that a new account needs review
+    await notifyAdminOfNewApplication({
+      displayName: data.display_name,
+      linkedinUrl: data.linkedin_url,
+      userEmail: user.email ?? "unknown",
+    });
+  }
 
   revalidatePath("/", "layout");
   return {};


### PR DESCRIPTION
## Summary

- Adds an opt-in `LOCAL_DEV_AUTO_ADMIN` env flag so new volunteer engineers can finish onboarding locally without manual Supabase approval.
- When enabled, onboarding sets `approval_status: approved` and `role: admin`, and skips the admin notification email.
- Documents the flag in `.env.example` and the README getting-started section.

Production behavior is unchanged unless the flag is explicitly set.

## Test plan

- [ ] With `LOCAL_DEV_AUTO_ADMIN=true` in `.env.local`, sign up and complete onboarding → lands on `/dashboard` (not `/pending-approval`) with admin access (e.g. `/admin/approvals` loads).
- [ ] Without the flag (or set to anything other than `"true"`), complete onboarding → `approval_status` is `pending` and user is held at `/pending-approval`.
- [ ] With the flag enabled, confirm no admin notification email is sent on onboarding.
- [ ] Confirm preview/production deploys do **not** set this env var.