### PR TITLE
feat: dashboard refresh, weekly schedule tabs, and feature gates

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -71,7 +71,7 @@ jobs:
         if: steps.changes.outputs.migrations == 'true'
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.PREVIEW_SUPABASE_ACCESS_TOKEN }}
-        run: supabase db push
+        run: supabase db push --include-all
 
       - name: Install Vercel CLI
         run: npm install -g vercel@54.2.0

--- a/app/(app)/app-shell.tsx
+++ b/app/(app)/app-shell.tsx
@@ -15,9 +15,7 @@ import {
   Briefcase,
   ClipboardList,
   Link2,
-  BookMarked,
   ListTodo,
-  GitFork,
   ExternalLink,
 } from "lucide-react";
 import dynamic from "next/dynamic";
@@ -33,6 +31,7 @@ import { cn } from "@/lib/utils";
 import { UserAvatar } from "@/components/shared/UserAvatar";
 import { updateLastSeen } from "@/app/(app)/profile/actions";
 import { syncBrowserTimezone } from "@/lib/actions/timezone";
+import { featureFlags } from "@/lib/feature-flags";
 
 const HEARTBEAT_INTERVAL_MS = 45_000; // 45s — keep last_seen_at fresh so others see you online
 
@@ -51,10 +50,10 @@ const myToolsNavItems = [
 ];
 
 const resourcesNavItems = [
-  { href: "/jobs",         label: "Job Board",      icon: Briefcase },
-  { href: "/learning",     label: "Group Learning", icon: BookMarked },
-  { href: "/projects",     label: "Projects",       icon: GitFork },
-  { href: "/links",        label: "Resource Hub",   icon: Link2 },
+  ...(featureFlags.ghostJobBoard
+    ? [{ href: "/jobs" as const, label: "Ghost Job Board", icon: Briefcase }]
+    : []),
+  { href: "/links", label: "Resource Hub", icon: Link2 },
 ];
 
 const profileNavItems = [
@@ -184,21 +183,25 @@ export default function AppShell({ children, user }: AppShellProps) {
               Join Slack
             </a>
 
-            <Separator className="my-2" />
-            <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60">
-              My Tools
-            </p>
-            {myToolsNavItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setSidebarOpen(false)}
-                className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-              >
-                <item.icon className="size-5 shrink-0" />
-                {item.label}
-              </Link>
-            ))}
+            {featureFlags.myToolsNav && (
+              <>
+                <Separator className="my-2" />
+                <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60">
+                  My Tools
+                </p>
+                {myToolsNavItems.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setSidebarOpen(false)}
+                    className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                  >
+                    <item.icon className="size-5 shrink-0" />
+                    {item.label}
+                  </Link>
+                ))}
+              </>
+            )}
 
             <Separator className="my-2" />
             <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60">

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { WelcomeBanner } from "@/components/dashboard/WelcomeBanner";
 import { NewMembersCard } from "@/components/dashboard/NewMembersCard";
 import { PollsCardWrapper } from "@/components/dashboard/PollsCardWrapper";
-import { LeetcodeCard } from "@/components/dashboard/LeetcodeCard";
+import { RecentVideosCard } from "@/components/dashboard/RecentVideosCard";
 import { WeeklyScheduleCard } from "@/components/dashboard/WeeklyScheduleCard";
 import { AnnouncementsCard } from "@/components/dashboard/AnnouncementsCard";
 import { CardSkeleton } from "@/components/dashboard/CardSkeleton";
@@ -32,7 +32,7 @@ export default async function DashboardPage() {
       <AnnouncementsCard />
       <WeeklyScheduleCard rows={scheduleRows ?? []} isPlatformAdmin={isPlatformAdmin} />
 
-      <LeetcodeCard />
+      <RecentVideosCard />
 
       <Suspense fallback={<CardSkeleton />}>
         <PollsCardWrapper userId={user.id} />

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -18,7 +18,10 @@ export default async function DashboardPage() {
 
   const [{ data: profile }, { data: scheduleRows }] = await Promise.all([
     supabase.from("profiles").select("*").eq("id", user.id).single(),
-    supabase.from("weekly_schedule").select("id, name, days, time, zoom_url, position").order("position", { ascending: true }),
+    supabase
+      .from("weekly_schedule")
+      .select("id, name, days, time, zoom_url, position, category")
+      .order("position", { ascending: true }),
   ]);
 
   const isPlatformAdmin = profile?.role === "admin";

--- a/app/(app)/dashboard/schedule-actions.ts
+++ b/app/(app)/dashboard/schedule-actions.ts
@@ -2,30 +2,47 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
+import type { ScheduleCategory } from "@/lib/utils/weekly-schedule";
 
 async function requireAdmin() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) throw new Error("Not authenticated");
+
   const { data: profile } = await supabase
     .from("profiles")
     .select("role")
     .eq("id", user.id)
     .single();
   if (profile?.role !== "admin") throw new Error("Not authorized");
+
   return supabase;
 }
 
-export async function createScheduleRow(
-  row: { name: string; days: string; time: string; zoom_url: string; position: number }
-): Promise<{ error?: string }> {
+export async function createScheduleRow(row: {
+  name: string;
+  days: string;
+  time: string;
+  zoom_url: string;
+  position: number;
+  category: ScheduleCategory;
+}): Promise<{ error?: string }> {
   try {
     const supabase = await requireAdmin();
-    const { error } = await supabase.from("weekly_schedule").insert({
-      ...row,
-      zoom_url: row.zoom_url.trim() || null,
-    });
+    const { data, error } = await supabase
+      .from("weekly_schedule")
+      .insert({
+        ...row,
+        zoom_url: row.zoom_url.trim() || null,
+      })
+      .select("id")
+      .single();
+
     if (error) return { error: error.message };
+    if (!data) return { error: "Insert failed — no row returned" };
+
     revalidatePath("/dashboard");
     return {};
   } catch (e) {
@@ -35,15 +52,31 @@ export async function createScheduleRow(
 
 export async function updateScheduleRow(
   id: string,
-  row: { name: string; days: string; time: string; zoom_url: string }
+  row: {
+    name: string;
+    days: string;
+    time: string;
+    zoom_url: string;
+  }
 ): Promise<{ error?: string }> {
   try {
     const supabase = await requireAdmin();
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("weekly_schedule")
-      .update({ ...row, zoom_url: row.zoom_url.trim() || null, updated_at: new Date().toISOString() })
-      .eq("id", id);
+      .update({
+        name: row.name,
+        days: row.days,
+        time: row.time,
+        zoom_url: row.zoom_url.trim() || null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", id)
+      .select("id")
+      .single();
+
     if (error) return { error: error.message };
+    if (!data) return { error: "Update failed — row not found" };
+
     revalidatePath("/dashboard");
     return {};
   } catch (e) {
@@ -54,8 +87,16 @@ export async function updateScheduleRow(
 export async function deleteScheduleRow(id: string): Promise<{ error?: string }> {
   try {
     const supabase = await requireAdmin();
-    const { error } = await supabase.from("weekly_schedule").delete().eq("id", id);
+    const { data, error } = await supabase
+      .from("weekly_schedule")
+      .delete()
+      .eq("id", id)
+      .select("id")
+      .single();
+
     if (error) return { error: error.message };
+    if (!data) return { error: "Delete failed — row not found" };
+
     revalidatePath("/dashboard");
     return {};
   } catch (e) {

--- a/app/(app)/jobs/JobBoardClient.tsx
+++ b/app/(app)/jobs/JobBoardClient.tsx
@@ -165,9 +165,9 @@ export function JobBoardClient({
       {/* ── Top bar ── */}
       <div className="shrink-0 flex items-center justify-between gap-4 border-b bg-background px-4 py-3 lg:px-6">
         <div>
-          <h1 className="text-xl font-bold">Community Job Board</h1>
+          <h1 className="text-xl font-bold">Ghost Job Board</h1>
           <p className="text-xs text-muted-foreground">
-            Add a job to your Job Tracker wishlist and share Community Notes.
+            Anonymously share your experience here.
           </p>
         </div>
         <PostJobForm />

--- a/app/(app)/jobs/PostJobForm.tsx
+++ b/app/(app)/jobs/PostJobForm.tsx
@@ -106,12 +106,12 @@ export function PostJobForm() {
       <DialogTrigger asChild>
         <Button className="gap-1.5">
           <Plus className="size-4" />
-          Post a Job
+          Report a Ghost
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Post a Job</DialogTitle>
+          <DialogTitle>Report a Ghost</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4 mt-2">
           <div className="grid grid-cols-2 gap-3">
@@ -257,7 +257,7 @@ export function PostJobForm() {
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
             <Button type="submit" disabled={loading}>
               {loading && <Loader2 className="size-4 mr-2 animate-spin" />}
-              Post Job
+              Report a Ghost
             </Button>
           </div>
         </form>

--- a/app/(app)/jobs/page.tsx
+++ b/app/(app)/jobs/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { FeatureComingSoon } from "@/components/shared/FeatureComingSoon";
+import { featureFlags } from "@/lib/feature-flags";
 import { JobBoardClient, type JobPosting } from "./JobBoardClient";
 import type { Comment } from "./JobComments";
 
@@ -9,14 +11,22 @@ export default async function JobBoardPage({
 }: {
   searchParams: Promise<{ role?: string; referral?: string; community?: string; notes?: string }>;
 }) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  if (!featureFlags.ghostJobBoard) {
+    return (
+      <div className="mx-auto max-w-7xl">
+        <FeatureComingSoon />
+      </div>
+    );
+  }
+
   const { role: roleFilter, referral, community, notes } = await searchParams;
   const referralFilter = referral === "true";
   const communityFilter = community === "true";
   const notesFilter = notes === "true";
-
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect("/login");
 
   let jobQuery = supabase
     .from("job_postings")

--- a/app/(app)/learning/tracker/page.tsx
+++ b/app/(app)/learning/tracker/page.tsx
@@ -1,5 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { FeatureComingSoon } from "@/components/shared/FeatureComingSoon";
+import { featureFlags } from "@/lib/feature-flags";
 import { ListTodo } from "lucide-react";
 import { LearningTrackerClient } from "./LearningTrackerClient";
 import type { TrackerItem } from "../page";
@@ -20,6 +22,14 @@ export default async function LearningTrackerPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/login");
+
+  if (!featureFlags.learningTracker) {
+    return (
+      <div className="mx-auto max-w-7xl">
+        <FeatureComingSoon />
+      </div>
+    );
+  }
 
   // ── Tracker items ────────────────────────────────────────────────────────────
   const { data: raw } = await supabase

--- a/app/(app)/links/ResourceHubClient.tsx
+++ b/app/(app)/links/ResourceHubClient.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { ExternalLink, Link2 } from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { DeleteLinkButton } from "./DeleteLinkButton";
+import { CATEGORY_META, SECTIONS } from "./constants";
+import type { LinkCategory } from "./actions";
+import type { Profile } from "@/lib/types";
+
+export interface CommunityLink {
+  id: string;
+  title: string;
+  url: string;
+  description: string | null;
+  category: LinkCategory;
+  posted_by: string;
+  created_at: string;
+  poster: Pick<Profile, "id" | "display_name"> | null;
+}
+
+interface ResourceHubClientProps {
+  links: CommunityLink[];
+  currentUserId: string;
+  isPlatformAdmin: boolean;
+}
+
+function LinkCard({
+  link,
+  cat,
+  canDelete,
+}: {
+  link: CommunityLink;
+  cat: LinkCategory;
+  canDelete: boolean;
+}) {
+  const meta = CATEGORY_META[cat];
+
+  return (
+    <div className="group relative flex flex-col gap-1.5 rounded-xl border bg-card p-4 transition-colors hover:border-primary/30">
+      <div className="flex items-start justify-between gap-2">
+        <a
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 text-sm font-semibold leading-snug text-foreground transition-colors hover:text-primary"
+        >
+          {link.title}
+          <ExternalLink className="size-3 shrink-0 opacity-60" />
+        </a>
+        {canDelete && <DeleteLinkButton id={link.id} />}
+      </div>
+
+      <span
+        className={`self-start rounded-full border px-2 py-0.5 text-[11px] font-medium ${meta.bg} ${meta.color}`}
+      >
+        {meta.label}
+      </span>
+
+      {link.description && (
+        <p className="line-clamp-3 text-xs leading-relaxed text-muted-foreground">
+          {link.description}
+        </p>
+      )}
+
+      <p className="mt-auto truncate pt-1 text-[11px] text-muted-foreground/70">
+        {link.url}
+      </p>
+
+      {link.poster && (
+        <p className="text-[11px] text-muted-foreground">
+          Shared by {link.poster.display_name}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function SectionContent({
+  sectionId,
+  grouped,
+  currentUserId,
+  isPlatformAdmin,
+}: {
+  sectionId: string;
+  grouped: Map<LinkCategory, CommunityLink[]>;
+  currentUserId: string;
+  isPlatformAdmin: boolean;
+}) {
+  const section = SECTIONS.find((s) => s.id === sectionId);
+  if (!section) return null;
+
+  const sectionItems = section.categories.flatMap((cat) =>
+    (grouped.get(cat) ?? []).map((link) => ({ link, cat }))
+  );
+  const hasSubSections = section.categories.length > 1;
+
+  if (sectionItems.length === 0) {
+    return (
+      <p className="py-12 text-center text-sm text-muted-foreground">
+        No resources in this section yet.
+      </p>
+    );
+  }
+
+  if (hasSubSections) {
+    return (
+      <div className="space-y-6">
+        {section.categories.map((cat) => {
+          const items = grouped.get(cat) ?? [];
+          if (items.length === 0) return null;
+          const meta = CATEGORY_META[cat];
+          return (
+            <div key={cat} className="space-y-2">
+              <h3 className="pl-0.5 text-xs font-semibold text-muted-foreground">
+                {meta.label}
+              </h3>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {items.map((link) => (
+                  <LinkCard
+                    key={link.id}
+                    link={link}
+                    cat={cat}
+                    canDelete={
+                      isPlatformAdmin || link.posted_by === currentUserId
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {sectionItems.map(({ link, cat }) => (
+        <LinkCard
+          key={link.id}
+          link={link}
+          cat={cat}
+          canDelete={isPlatformAdmin || link.posted_by === currentUserId}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function ResourceHubClient({
+  links,
+  currentUserId,
+  isPlatformAdmin,
+}: ResourceHubClientProps) {
+  const grouped = new Map<LinkCategory, CommunityLink[]>();
+  for (const link of links) {
+    const cat = link.category ?? "other";
+    if (!grouped.has(cat)) grouped.set(cat, []);
+    grouped.get(cat)!.push(link);
+  }
+
+  const defaultTab =
+    SECTIONS.find((section) =>
+      section.categories.some((cat) => (grouped.get(cat)?.length ?? 0) > 0)
+    )?.id ?? SECTIONS[0].id;
+
+  if (links.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <div className="mb-4 flex size-16 items-center justify-center rounded-full bg-muted">
+          <Link2 className="size-8 text-muted-foreground" />
+        </div>
+        <h2 className="text-lg font-semibold">No links shared yet</h2>
+        <p className="mt-1 max-w-xs text-sm text-muted-foreground">
+          Be the first to share a useful resource with the community.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <Tabs defaultValue={defaultTab}>
+      <div className="-mx-1 overflow-x-auto px-1 pb-1">
+        <TabsList
+          variant="line"
+          className="h-auto min-w-full w-max flex-wrap justify-start gap-x-1 gap-y-1"
+        >
+          {SECTIONS.map((section) => {
+            const count = section.categories.reduce(
+              (sum, cat) => sum + (grouped.get(cat)?.length ?? 0),
+              0
+            );
+            return (
+              <TabsTrigger
+                key={section.id}
+                value={section.id}
+                className="px-2.5 py-1.5 text-xs sm:text-sm"
+              >
+                {section.tabLabel}
+                {count > 0 && (
+                  <span className="text-muted-foreground">({count})</span>
+                )}
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
+      </div>
+
+      {SECTIONS.map((section) => (
+        <TabsContent key={section.id} value={section.id} className="mt-6">
+          <h2 className="sr-only">{section.heading}</h2>
+          <SectionContent
+            sectionId={section.id}
+            grouped={grouped}
+            currentUserId={currentUserId}
+            isPlatformAdmin={isPlatformAdmin}
+          />
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}

--- a/app/(app)/links/constants.ts
+++ b/app/(app)/links/constants.ts
@@ -1,0 +1,113 @@
+import type { LinkCategory } from "./actions";
+
+export const CATEGORY_META: Record<
+  LinkCategory,
+  { label: string; color: string; bg: string }
+> = {
+  organization: {
+    label: "Organization",
+    color: "text-blue-700",
+    bg: "bg-blue-100 border-blue-200",
+  },
+  community: {
+    label: "Community / Networking",
+    color: "text-indigo-700",
+    bg: "bg-indigo-100 border-indigo-200",
+  },
+  job_board_general: {
+    label: "General",
+    color: "text-violet-700",
+    bg: "bg-violet-100 border-violet-200",
+  },
+  job_board_remote: {
+    label: "Remote-Focused",
+    color: "text-cyan-700",
+    bg: "bg-cyan-100 border-cyan-200",
+  },
+  job_board_civic: {
+    label: "Civic Tech Jobs",
+    color: "text-emerald-700",
+    bg: "bg-emerald-100 border-emerald-200",
+  },
+  labor_org: {
+    label: "Labor Organization",
+    color: "text-rose-700",
+    bg: "bg-rose-100 border-rose-200",
+  },
+  learning: {
+    label: "Learning Material",
+    color: "text-green-700",
+    bg: "bg-green-100 border-green-200",
+  },
+  tool: {
+    label: "Tool / App",
+    color: "text-purple-700",
+    bg: "bg-purple-100 border-purple-200",
+  },
+  article: {
+    label: "Article / Blog",
+    color: "text-amber-700",
+    bg: "bg-amber-100 border-amber-200",
+  },
+  other: {
+    label: "Other",
+    color: "text-slate-600",
+    bg: "bg-slate-100 border-slate-200",
+  },
+};
+
+export const SECTIONS: {
+  id: string;
+  heading: string;
+  tabLabel: string;
+  categories: LinkCategory[];
+}[] = [
+  {
+    id: "organizations",
+    heading: "Organizations",
+    tabLabel: "Organizations",
+    categories: ["organization"],
+  },
+  {
+    id: "communities",
+    heading: "Communities & Networking",
+    tabLabel: "Communities",
+    categories: ["community"],
+  },
+  {
+    id: "job-search",
+    heading: "Job Search Platforms",
+    tabLabel: "Job Search",
+    categories: ["job_board_remote", "job_board_civic", "job_board_general"],
+  },
+  {
+    id: "labor-orgs",
+    heading: "Labor Orgs",
+    tabLabel: "Labor Orgs",
+    categories: ["labor_org"],
+  },
+  {
+    id: "learning",
+    heading: "Learning Materials",
+    tabLabel: "Learning",
+    categories: ["learning"],
+  },
+  {
+    id: "tools",
+    heading: "Tools & Apps",
+    tabLabel: "Tools",
+    categories: ["tool"],
+  },
+  {
+    id: "articles",
+    heading: "Articles & Blogs",
+    tabLabel: "Articles",
+    categories: ["article"],
+  },
+  {
+    id: "other",
+    heading: "Other",
+    tabLabel: "Other",
+    categories: ["other"],
+  },
+];

--- a/app/(app)/links/page.tsx
+++ b/app/(app)/links/page.tsx
@@ -1,218 +1,64 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import { ExternalLink, Link2 } from "lucide-react";
+import {
+  ResourceHubClient,
+  type CommunityLink,
+} from "./ResourceHubClient";
 import { PostLinkForm } from "./PostLinkForm";
-import { DeleteLinkButton } from "./DeleteLinkButton";
+import type { LinkCategory } from "./actions";
 import type { Profile } from "@/lib/types";
-
-type LinkCategory =
-  | "organization"
-  | "learning"
-  | "tool"
-  | "article"
-  | "other"
-  | "job_board_general"
-  | "job_board_remote"
-  | "job_board_civic"
-  | "community"
-  | "labor_org";
-
-const CATEGORY_META: Record<
-  LinkCategory,
-  { label: string; color: string; bg: string }
-> = {
-  organization:     { label: "Organization",            color: "text-blue-700",   bg: "bg-blue-100 border-blue-200" },
-  community:        { label: "Community / Networking",  color: "text-indigo-700", bg: "bg-indigo-100 border-indigo-200" },
-  job_board_general:{ label: "General",                 color: "text-violet-700", bg: "bg-violet-100 border-violet-200" },
-  job_board_remote: { label: "Remote-Focused",          color: "text-cyan-700",   bg: "bg-cyan-100 border-cyan-200" },
-  job_board_civic:  { label: "Civic Tech Jobs",          color: "text-emerald-700",bg: "bg-emerald-100 border-emerald-200" },
-  labor_org:        { label: "Labor Organization",        color: "text-rose-700",   bg: "bg-rose-100 border-rose-200" },
-  learning:         { label: "Learning Material",       color: "text-green-700",  bg: "bg-green-100 border-green-200" },
-  tool:             { label: "Tool / App",              color: "text-purple-700", bg: "bg-purple-100 border-purple-200" },
-  article:          { label: "Article / Blog",          color: "text-amber-700",  bg: "bg-amber-100 border-amber-200" },
-  other:            { label: "Other",                   color: "text-slate-600",  bg: "bg-slate-100 border-slate-200" },
-};
-
-// Top-level sections — each can have one or more categories underneath it
-const SECTIONS: {
-  heading: string;
-  categories: LinkCategory[];
-}[] = [
-  {
-    heading: "Communities & Networking",
-    categories: ["community"],
-  },
-  {
-    heading: "Labor Orgs",
-    categories: ["labor_org"],
-  },
-  {
-    heading: "Job Search Platforms",
-    categories: ["job_board_remote", "job_board_civic", "job_board_general"],
-  },
-  {
-    heading: "Organizations",
-    categories: ["organization"],
-  },
-  {
-    heading: "Learning Materials",
-    categories: ["learning"],
-  },
-  {
-    heading: "Tools & Apps",
-    categories: ["tool"],
-  },
-  {
-    heading: "Articles & Blogs",
-    categories: ["article"],
-  },
-  {
-    heading: "Other",
-    categories: ["other"],
-  },
-];
 
 export default async function CommunityLinksPage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
   const [{ data: links }, { data: profile }] = await Promise.all([
     supabase
       .from("community_links")
-      .select("id, title, url, description, category, posted_by, created_at, poster:posted_by(id, display_name)")
+      .select(
+        "id, title, url, description, category, posted_by, created_at, poster:posted_by(id, display_name)"
+      )
       .order("created_at", { ascending: true }),
     supabase.from("profiles").select("role").eq("id", user.id).single(),
   ]);
 
   const isPlatformAdmin = profile?.role === "admin";
 
-  // Group by category
-  const grouped = new Map<LinkCategory, typeof links>();
-  for (const link of links ?? []) {
-    const cat = (link.category as LinkCategory) ?? "other";
-    if (!grouped.has(cat)) grouped.set(cat, []);
-    grouped.get(cat)!.push(link);
-  }
-
-  const totalCount = links?.length ?? 0;
-
-  function LinkCard({ link, cat }: { link: NonNullable<typeof links>[number]; cat: LinkCategory }) {
-    const posterRaw = Array.isArray(link.poster) ? (link.poster[0] ?? null) : link.poster;
-    const poster = posterRaw as Pick<Profile, "id" | "display_name"> | null;
-    const canDelete = isPlatformAdmin || link.posted_by === user!.id;
-    const meta = CATEGORY_META[cat];
-
-    return (
-      <div className="group relative flex flex-col gap-1.5 rounded-xl border bg-card p-4 hover:border-primary/30 transition-colors">
-        <div className="flex items-start justify-between gap-2">
-          <a
-            href={link.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1.5 font-semibold text-sm text-foreground hover:text-primary transition-colors leading-snug"
-          >
-            {link.title}
-            <ExternalLink className="size-3 shrink-0 opacity-60" />
-          </a>
-          {canDelete && <DeleteLinkButton id={link.id} />}
-        </div>
-
-        <span className={`self-start text-[11px] font-medium px-2 py-0.5 rounded-full border ${meta.bg} ${meta.color}`}>
-          {meta.label}
-        </span>
-
-        {link.description && (
-          <p className="text-xs text-muted-foreground leading-relaxed line-clamp-3">
-            {link.description}
-          </p>
-        )}
-
-        <p className="text-[11px] text-muted-foreground/70 truncate mt-auto pt-1">
-          {link.url}
-        </p>
-
-        {poster && (
-          <p className="text-[11px] text-muted-foreground">
-            Shared by {poster.display_name}
-          </p>
-        )}
-      </div>
-    );
-  }
+  const normalizedLinks: CommunityLink[] = (links ?? []).map((link) => {
+    const posterRaw = Array.isArray(link.poster)
+      ? (link.poster[0] ?? null)
+      : link.poster;
+    return {
+      id: link.id,
+      title: link.title,
+      url: link.url,
+      description: link.description,
+      category: (link.category as LinkCategory) ?? "other",
+      posted_by: link.posted_by,
+      created_at: link.created_at,
+      poster: posterRaw as Pick<Profile, "id" | "display_name"> | null,
+    };
+  });
 
   return (
-    <div className="mx-auto max-w-4xl space-y-10">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div className="flex items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold">Resource Hub</h1>
-          <p className="text-sm text-muted-foreground mt-1">
+          <p className="mt-1 text-sm text-muted-foreground">
             Shared resources — organizations, learning materials, tools, and more.
           </p>
         </div>
         <PostLinkForm />
       </div>
-
-      {/* Empty state */}
-      {totalCount === 0 && (
-        <div className="flex flex-col items-center justify-center py-20 text-center">
-          <div className="mb-4 flex size-16 items-center justify-center rounded-full bg-muted">
-            <Link2 className="size-8 text-muted-foreground" />
-          </div>
-          <h2 className="text-lg font-semibold">No links shared yet</h2>
-          <p className="mt-1 text-sm text-muted-foreground max-w-xs">
-            Be the first to share a useful resource with the community.
-          </p>
-        </div>
-      )}
-
-      {/* Sections */}
-      {SECTIONS.map((section) => {
-        // Collect all items across this section's categories (in order)
-        const sectionItems = section.categories.flatMap((cat) =>
-          (grouped.get(cat) ?? []).map((link) => ({ link, cat }))
-        );
-        if (sectionItems.length === 0) return null;
-
-        // If the section has multiple categories, show sub-section headers
-        const hasSubSections = section.categories.length > 1;
-
-        return (
-          <section key={section.heading} className="space-y-4">
-            <h2 className="text-sm font-semibold uppercase tracking-widest text-muted-foreground border-b border-border pb-2">
-              {section.heading}
-            </h2>
-
-            {hasSubSections ? (
-              // Render each category as a sub-section
-              section.categories.map((cat) => {
-                const items = grouped.get(cat) ?? [];
-                if (items.length === 0) return null;
-                const meta = CATEGORY_META[cat];
-                return (
-                  <div key={cat} className="space-y-2">
-                    <h3 className="text-xs font-semibold text-muted-foreground pl-0.5">
-                      {meta.label}
-                    </h3>
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      {items.map((link) => (
-                        <LinkCard key={link.id} link={link} cat={cat} />
-                      ))}
-                    </div>
-                  </div>
-                );
-              })
-            ) : (
-              <div className="grid gap-3 sm:grid-cols-2">
-                {sectionItems.map(({ link, cat }) => (
-                  <LinkCard key={link.id} link={link} cat={cat} />
-                ))}
-              </div>
-            )}
-          </section>
-        );
-      })}
+      <ResourceHubClient
+        links={normalizedLinks}
+        currentUserId={user.id}
+        isPlatformAdmin={isPlatformAdmin}
+      />
     </div>
   );
 }

--- a/app/(app)/tracker/page.tsx
+++ b/app/(app)/tracker/page.tsx
@@ -1,5 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { FeatureComingSoon } from "@/components/shared/FeatureComingSoon";
+import { featureFlags } from "@/lib/feature-flags";
 import { TrackerClient, type Application, type CommunityNote } from "./TrackerClient";
 import type { Interview, HelpRequest } from "./actions";
 
@@ -7,6 +9,14 @@ export default async function TrackerPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/login");
+
+  if (!featureFlags.jobApplicationTracker) {
+    return (
+      <div className="mx-auto max-w-7xl">
+        <FeatureComingSoon />
+      </div>
+    );
+  }
 
   const [{ data: rawApplications }, { data: rawInterviews }, { data: rawHelp }] = await Promise.all([
     supabase

--- a/app/globals.css
+++ b/app/globals.css
@@ -152,3 +152,36 @@ html {
     @apply bg-background text-foreground font-sans;
   }
 }
+
+/* Weekly schedule tabs — uses brand tokens from :root (wwwrise.org/branding) */
+@layer components {
+  .schedule-tab-active-primary {
+    @apply bg-primary-orange text-white shadow-sm hover:bg-primary-orange-hover;
+  }
+  .schedule-tab-inactive-primary {
+    @apply bg-primary-orange/10 text-primary-orange hover:bg-primary-orange/15 dark:bg-primary-orange/15 dark:hover:bg-primary-orange/25;
+  }
+  .schedule-join-primary {
+    @apply bg-primary-orange/10 text-primary-orange hover:bg-primary-orange/15 dark:bg-primary-orange/15 dark:hover:bg-primary-orange/25;
+  }
+
+  .schedule-tab-active-green {
+    @apply bg-accent-green text-white shadow-sm hover:opacity-90;
+  }
+  .schedule-tab-inactive-green {
+    @apply bg-accent-green/10 text-accent-green hover:bg-accent-green/15 dark:bg-accent-green/15 dark:hover:bg-accent-green/25;
+  }
+  .schedule-join-green {
+    @apply bg-accent-green/10 text-accent-green hover:bg-accent-green/15 dark:bg-accent-green/15 dark:hover:bg-accent-green/25;
+  }
+
+  .schedule-tab-active-tertiary {
+    @apply bg-accent-blue text-white shadow-sm;
+  }
+  .schedule-tab-inactive-tertiary {
+    @apply bg-accent-blue/10 text-accent-blue hover:bg-accent-blue/15 dark:bg-accent-blue/20 dark:hover:bg-accent-blue/30;
+  }
+  .schedule-join-tertiary {
+    @apply bg-accent-blue/10 text-accent-blue hover:bg-accent-blue/15 dark:bg-accent-blue/20 dark:hover:bg-accent-blue/30;
+  }
+}

--- a/components/dashboard/AnnouncementsCard.tsx
+++ b/components/dashboard/AnnouncementsCard.tsx
@@ -24,54 +24,54 @@ export async function AnnouncementsCard() {
   if (items.length === 0 && !isPlatformAdmin) return null;
 
   return (
-    <div className="col-span-full rounded-xl overflow-hidden border border-border shadow-sm">
-      {/* Gray header bar */}
-      <div className="flex items-center gap-2 bg-muted px-4 py-2.5 border-b">
-        <Megaphone className="size-4 text-muted-foreground shrink-0" />
-        <span className="text-sm font-semibold text-foreground uppercase tracking-wide">
-          Announcements
+    <div className="col-span-full overflow-hidden rounded-xl border border-border border-l-4 border-l-accent-gold shadow-sm">
+      <div className="flex items-center gap-2 border-b bg-muted px-4 py-2.5">
+        <Megaphone className="size-4 shrink-0 text-accent-gold" />
+        <span className="text-sm font-semibold tracking-wide text-foreground">
+          News & Updates
         </span>
       </div>
 
-      {/* Announcement items */}
-      {items.length > 0 ? (
-        <ul className="divide-y bg-card">
-          {items.map((a) => (
-            <li key={a.id} className="px-4 py-3 text-sm text-foreground leading-relaxed">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                components={{
-                  p: ({ children }) => <p className="mb-1.5 last:mb-0">{children}</p>,
-                  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-                  em: ({ children }) => <em className="italic">{children}</em>,
-                  a: ({ href, children }) => (
-                    <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2 hover:opacity-80">
-                      {children}
-                    </a>
-                  ),
-                  ul: ({ children }) => <ul className="list-disc list-inside space-y-0.5 mb-1.5">{children}</ul>,
-                  ol: ({ children }) => <ol className="list-decimal list-inside space-y-0.5 mb-1.5">{children}</ol>,
-                  li: ({ children }) => <li className="text-sm">{children}</li>,
-                  code: ({ children }) => (
-                    <code className="bg-muted px-1 py-0.5 rounded text-xs font-mono">{children}</code>
-                  ),
-                  h1: ({ children }) => <h1 className="text-base font-bold mb-1">{children}</h1>,
-                  h2: ({ children }) => <h2 className="text-sm font-bold mb-1">{children}</h2>,
-                  h3: ({ children }) => <h3 className="text-sm font-semibold mb-1">{children}</h3>,
-                  hr: () => <hr className="my-2 border-border" />,
-                  blockquote: ({ children }) => (
-                    <blockquote className="border-l-2 border-muted-foreground/40 pl-3 italic text-muted-foreground">{children}</blockquote>
-                  ),
-                }}
-              >
-                {a.content}
-              </ReactMarkdown>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="px-4 py-3 text-sm text-muted-foreground italic">No announcements yet.</p>
-      )}
+      <div className="max-h-64 overflow-y-auto bg-card">
+        {items.length > 0 ? (
+          <ul className="divide-y">
+            {items.map((a) => (
+              <li key={a.id} className="px-4 py-3 text-sm leading-relaxed text-foreground">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    p: ({ children }) => <p className="mb-1.5 last:mb-0">{children}</p>,
+                    strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+                    em: ({ children }) => <em className="italic">{children}</em>,
+                    a: ({ href, children }) => (
+                      <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2 hover:opacity-80">
+                        {children}
+                      </a>
+                    ),
+                    ul: ({ children }) => <ul className="list-disc list-inside space-y-0.5 mb-1.5">{children}</ul>,
+                    ol: ({ children }) => <ol className="list-decimal list-inside space-y-0.5 mb-1.5">{children}</ol>,
+                    li: ({ children }) => <li className="text-sm">{children}</li>,
+                    code: ({ children }) => (
+                      <code className="rounded bg-muted px-1 py-0.5 text-xs font-mono">{children}</code>
+                    ),
+                    h1: ({ children }) => <h1 className="text-base font-bold mb-1">{children}</h1>,
+                    h2: ({ children }) => <h2 className="text-sm font-bold mb-1">{children}</h2>,
+                    h3: ({ children }) => <h3 className="text-sm font-semibold mb-1">{children}</h3>,
+                    hr: () => <hr className="my-2 border-border" />,
+                    blockquote: ({ children }) => (
+                      <blockquote className="border-l-2 border-muted-foreground/40 pl-3 italic text-muted-foreground">{children}</blockquote>
+                    ),
+                  }}
+                >
+                  {a.content}
+                </ReactMarkdown>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="px-4 py-3 text-sm italic text-muted-foreground">No announcements yet.</p>
+        )}
+      </div>
 
       {/* Admin controls */}
       {isPlatformAdmin && <AnnouncementsAdmin announcements={items} />}

--- a/components/dashboard/PollsCard.tsx
+++ b/components/dashboard/PollsCard.tsx
@@ -98,7 +98,7 @@ export function PollsCard({ userId, initialPoll }: PollsCardProps) {
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
             <BarChart3 className="size-4" />
-            Community Polls
+            Community Poll
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -118,7 +118,7 @@ export function PollsCard({ userId, initialPoll }: PollsCardProps) {
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-base">
           <BarChart3 className="size-4" />
-          Community Polls
+          Community Poll
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">

--- a/components/dashboard/RecentVideosCard.tsx
+++ b/components/dashboard/RecentVideosCard.tsx
@@ -1,0 +1,92 @@
+import { formatDistanceToNow } from "date-fns";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { AlertCircle, ExternalLink, PlaySquare } from "lucide-react";
+import {
+  fetchRecentVideos,
+  WORKSHOPS_PLAYLIST_URL,
+} from "@/lib/youtube/recent-videos";
+
+export async function RecentVideosCard() {
+  const videos = await fetchRecentVideos(4);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <PlaySquare className="size-4 text-primary-orange" />
+          Recent Workshops
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {videos.length > 0 ? (
+          <div className="space-y-3">
+            <ul className="space-y-3">
+              {videos.map((video) => (
+                <li key={video.id}>
+                  <a
+                    href={video.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex gap-3 rounded-lg transition-colors hover:bg-muted/50"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={video.thumbnailUrl}
+                      alt=""
+                      className="h-14 w-24 shrink-0 rounded-md object-cover"
+                    />
+                    <div className="min-w-0 flex-1 py-0.5">
+                      <p className="line-clamp-2 text-sm font-medium leading-snug group-hover:text-primary-orange">
+                        {video.title}
+                      </p>
+                      {video.publishedAt && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {formatDistanceToNow(new Date(video.publishedAt), {
+                            addSuffix: true,
+                          })}
+                        </p>
+                      )}
+                    </div>
+                  </a>
+                </li>
+              ))}
+            </ul>
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              className="mt-1 w-full gap-1.5"
+            >
+              <a
+                href={WORKSHOPS_PLAYLIST_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View all workshops
+                <ExternalLink className="size-3.5" />
+              </a>
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-2 py-6 text-center">
+            <AlertCircle className="size-8 text-muted-foreground/50" />
+            <p className="text-sm text-muted-foreground">
+              No workshops loaded yet.
+            </p>
+            <Button asChild variant="outline" size="sm" className="gap-1.5">
+              <a
+                href={WORKSHOPS_PLAYLIST_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Watch on YouTube
+                <ExternalLink className="size-3.5" />
+              </a>
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/dashboard/WeeklyScheduleAdmin.tsx
+++ b/components/dashboard/WeeklyScheduleAdmin.tsx
@@ -1,51 +1,106 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Pencil, Trash2, Plus, Check, X, Loader2, Video } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useRouter } from "next/navigation";
 import {
   createScheduleRow,
   updateScheduleRow,
   deleteScheduleRow,
 } from "@/app/(app)/dashboard/schedule-actions";
-
-interface ScheduleRow {
-  id: string;
-  name: string;
-  days: string;
-  time: string;
-  zoom_url: string | null;
-  position: number;
-}
+import {
+  SCHEDULE_CATEGORIES,
+  type ScheduleCategory,
+  type ScheduleRow,
+} from "@/lib/utils/weekly-schedule";
 
 interface Props {
   rows: ScheduleRow[];
+  activeCategory: ScheduleCategory;
+  onAddingChange?: (adding: boolean) => void;
 }
 
-const EMPTY = { name: "", days: "", time: "", zoom_url: "" };
+type RowForm = {
+  name: string;
+  days: string;
+  time: string;
+  zoom_url: string;
+  category: ScheduleCategory;
+};
 
-export function WeeklyScheduleAdmin({ rows: initialRows }: Props) {
+function emptyForm(category: ScheduleCategory): RowForm {
+  return { name: "", days: "", time: "", zoom_url: "", category };
+}
+
+export function WeeklyScheduleAdmin({
+  rows: initialRows,
+  activeCategory,
+  onAddingChange,
+}: Props) {
   const router = useRouter();
   const [rows, setRows] = useState<ScheduleRow[]>(initialRows);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editRow, setEditRow] = useState(EMPTY);
+  const [editRow, setEditRow] = useState<RowForm>(() => emptyForm(activeCategory));
   const [adding, setAdding] = useState(false);
-  const [newRow, setNewRow] = useState(EMPTY);
+  const [newRow, setNewRow] = useState<RowForm>(() => emptyForm(activeCategory));
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const visibleRows = useMemo(
+    () =>
+      rows
+        .filter((row) => row.category === activeCategory)
+        .sort((a, b) => a.position - b.position),
+    [rows, activeCategory]
+  );
+
+  useEffect(() => {
+    setAdding(false);
+    setEditingId(null);
+    setNewRow(emptyForm(activeCategory));
+    setEditRow(emptyForm(activeCategory));
+  }, [activeCategory]);
+
+  useEffect(() => {
+    setRows(initialRows);
+  }, [initialRows]);
+
+  useEffect(() => {
+    onAddingChange?.(adding);
+  }, [adding, onAddingChange]);
+
   async function handleSaveEdit(id: string) {
     if (!editRow.name.trim()) return;
-    setBusy(true); setError(null);
-    const res = await updateScheduleRow(id, editRow);
+    setBusy(true);
+    setError(null);
+    const res = await updateScheduleRow(id, {
+      name: editRow.name,
+      days: editRow.days,
+      time: editRow.time,
+      zoom_url: editRow.zoom_url,
+    });
     setBusy(false);
-    if (res.error) { setError(res.error); return; }
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
     setRows((prev) =>
       prev.map((r) =>
         r.id === id
-          ? { ...r, ...editRow, zoom_url: editRow.zoom_url.trim() || null }
+          ? {
+              ...r,
+              ...editRow,
+              zoom_url: editRow.zoom_url.trim() || null,
+            }
           : r
       )
     );
@@ -54,22 +109,33 @@ export function WeeklyScheduleAdmin({ rows: initialRows }: Props) {
   }
 
   async function handleDelete(id: string) {
-    setBusy(true); setError(null);
+    setBusy(true);
+    setError(null);
     const res = await deleteScheduleRow(id);
     setBusy(false);
-    if (res.error) { setError(res.error); return; }
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
     setRows((prev) => prev.filter((r) => r.id !== id));
     router.refresh();
   }
 
   async function handleAdd() {
     if (!newRow.name.trim()) return;
-    setBusy(true); setError(null);
-    const maxPos = rows.length > 0 ? Math.max(...rows.map((r) => r.position)) + 1 : 0;
+    setBusy(true);
+    setError(null);
+    const categoryRows = rows.filter((r) => r.category === newRow.category);
+    const maxPos =
+      categoryRows.length > 0
+        ? Math.max(...categoryRows.map((r) => r.position)) + 1
+        : 0;
     const res = await createScheduleRow({ ...newRow, position: maxPos });
     setBusy(false);
-    if (res.error) { setError(res.error); return; }
-    // Optimistically append; router.refresh() will replace with server-assigned id
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
     setRows((prev) => [
       ...prev,
       {
@@ -79,14 +145,60 @@ export function WeeklyScheduleAdmin({ rows: initialRows }: Props) {
         position: maxPos,
       },
     ]);
-    setNewRow(EMPTY);
+    setNewRow(emptyForm(activeCategory));
     setAdding(false);
     router.refresh();
   }
 
+  function CategorySelect({
+    value,
+    onChange,
+  }: {
+    value: ScheduleCategory;
+    onChange: (value: ScheduleCategory) => void;
+  }) {
+    return (
+      <Select value={value} onValueChange={(v) => onChange(v as ScheduleCategory)}>
+        <SelectTrigger className="h-7 w-full text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {SCHEDULE_CATEGORIES.map((cat) => (
+            <SelectItem key={cat.value} value={cat.value} className="text-xs">
+              {cat.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  function CategorySpacer() {
+    if (!adding) return null;
+    return <td className="px-4 py-2" aria-hidden />;
+  }
+
+  const rowColSpan = adding ? 6 : 5;
+
   return (
     <tbody>
-      {rows.map((row) => (
+      {error && (
+        <tr>
+          <td colSpan={rowColSpan} className="px-4 py-2">
+            <p className="text-xs text-destructive">{error}</p>
+          </td>
+        </tr>
+      )}
+
+      {visibleRows.length === 0 && !adding && (
+        <tr>
+          <td colSpan={rowColSpan} className="px-4 py-6 text-center text-sm text-muted-foreground">
+            No meetings in this category yet.
+          </td>
+        </tr>
+      )}
+
+      {visibleRows.map((row) =>
         editingId === row.id ? (
           <tr key={row.id} className="border-b bg-muted/30">
             <td className="px-4 py-2">
@@ -98,6 +210,7 @@ export function WeeklyScheduleAdmin({ rows: initialRows }: Props) {
                 autoFocus
               />
             </td>
+            <CategorySpacer />
             <td className="px-4 py-2">
               <Input
                 value={editRow.days}
@@ -117,25 +230,44 @@ export function WeeklyScheduleAdmin({ rows: initialRows }: Props) {
             <td className="px-4 py-2">
               <Input
                 value={editRow.zoom_url}
-                onChange={(e) => setEditRow((r) => ({ ...r, zoom_url: e.target.value }))}
+                onChange={(e) =>
+                  setEditRow((r) => ({ ...r, zoom_url: e.target.value }))
+                }
                 className="h-7 text-sm"
                 placeholder="https://zoom.us/j/..."
               />
             </td>
             <td className="px-2 py-2">
               <div className="flex gap-1">
-                <Button size="icon" variant="ghost" className="size-7" onClick={() => handleSaveEdit(row.id)} disabled={busy}>
-                  {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5 text-green-600" />}
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-7"
+                  onClick={() => handleSaveEdit(row.id)}
+                  disabled={busy}
+                >
+                  {busy ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <Check className="size-3.5 text-green-600" />
+                  )}
                 </Button>
-                <Button size="icon" variant="ghost" className="size-7" onClick={() => setEditingId(null)} disabled={busy}>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-7"
+                  onClick={() => setEditingId(null)}
+                  disabled={busy}
+                >
                   <X className="size-3.5" />
                 </Button>
               </div>
             </td>
           </tr>
         ) : (
-          <tr key={row.id} className="border-b group hover:bg-muted/20">
+          <tr key={row.id} className="group border-b hover:bg-muted/20">
             <td className="px-4 py-2.5 text-sm font-medium">{row.name}</td>
+            <CategorySpacer />
             <td className="px-4 py-2.5 text-sm text-muted-foreground">{row.days}</td>
             <td className="px-4 py-2.5 text-sm text-muted-foreground">{row.time}</td>
             <td className="px-4 py-2.5 text-sm">
@@ -154,49 +286,106 @@ export function WeeklyScheduleAdmin({ rows: initialRows }: Props) {
               )}
             </td>
             <td className="px-2 py-2">
-              <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                 <Button
                   size="icon"
                   variant="ghost"
                   className="size-7"
                   onClick={() => {
                     setEditingId(row.id);
-                    setEditRow({ name: row.name, days: row.days, time: row.time, zoom_url: row.zoom_url ?? "" });
+                    setEditRow({
+                      name: row.name,
+                      days: row.days,
+                      time: row.time,
+                      zoom_url: row.zoom_url ?? "",
+                      category: row.category,
+                    });
                   }}
                   disabled={busy}
                 >
                   <Pencil className="size-3.5" />
                 </Button>
-                <Button size="icon" variant="ghost" className="size-7 text-destructive hover:text-destructive" onClick={() => handleDelete(row.id)} disabled={busy}>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-7 text-destructive hover:text-destructive"
+                  onClick={() => handleDelete(row.id)}
+                  disabled={busy}
+                >
                   <Trash2 className="size-3.5" />
                 </Button>
               </div>
             </td>
           </tr>
         )
-      ))}
+      )}
 
-      {/* Add row */}
       {adding ? (
         <tr className="border-b bg-muted/20">
           <td className="px-4 py-2">
-            <Input value={newRow.name} onChange={(e) => setNewRow((r) => ({ ...r, name: e.target.value }))} className="h-7 text-sm" placeholder="Name" autoFocus />
+            <Input
+              value={newRow.name}
+              onChange={(e) => setNewRow((r) => ({ ...r, name: e.target.value }))}
+              className="h-7 text-sm"
+              placeholder="Name"
+              autoFocus
+            />
           </td>
           <td className="px-4 py-2">
-            <Input value={newRow.days} onChange={(e) => setNewRow((r) => ({ ...r, days: e.target.value }))} className="h-7 text-sm" placeholder="Days" />
+            <CategorySelect
+              value={newRow.category}
+              onChange={(category) => setNewRow((r) => ({ ...r, category }))}
+            />
           </td>
           <td className="px-4 py-2">
-            <Input value={newRow.time} onChange={(e) => setNewRow((r) => ({ ...r, time: e.target.value }))} className="h-7 text-sm" placeholder="Time" />
+            <Input
+              value={newRow.days}
+              onChange={(e) => setNewRow((r) => ({ ...r, days: e.target.value }))}
+              className="h-7 text-sm"
+              placeholder="Days"
+            />
           </td>
           <td className="px-4 py-2">
-            <Input value={newRow.zoom_url} onChange={(e) => setNewRow((r) => ({ ...r, zoom_url: e.target.value }))} className="h-7 text-sm" placeholder="https://zoom.us/j/..." />
+            <Input
+              value={newRow.time}
+              onChange={(e) => setNewRow((r) => ({ ...r, time: e.target.value }))}
+              className="h-7 text-sm"
+              placeholder="Time"
+            />
+          </td>
+          <td className="px-4 py-2">
+            <Input
+              value={newRow.zoom_url}
+              onChange={(e) => setNewRow((r) => ({ ...r, zoom_url: e.target.value }))}
+              className="h-7 text-sm"
+              placeholder="https://zoom.us/j/..."
+            />
           </td>
           <td className="px-2 py-2">
             <div className="flex gap-1">
-              <Button size="icon" variant="ghost" className="size-7" onClick={handleAdd} disabled={busy}>
-                {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5 text-green-600" />}
+              <Button
+                size="icon"
+                variant="ghost"
+                className="size-7"
+                onClick={handleAdd}
+                disabled={busy}
+              >
+                {busy ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <Check className="size-3.5 text-green-600" />
+                )}
               </Button>
-              <Button size="icon" variant="ghost" className="size-7" onClick={() => { setAdding(false); setNewRow(EMPTY); }} disabled={busy}>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="size-7"
+                onClick={() => {
+                  setAdding(false);
+                  setNewRow(emptyForm(activeCategory));
+                }}
+                disabled={busy}
+              >
                 <X className="size-3.5" />
               </Button>
             </div>
@@ -204,12 +393,16 @@ export function WeeklyScheduleAdmin({ rows: initialRows }: Props) {
         </tr>
       ) : (
         <tr>
-          <td colSpan={5} className="px-4 py-2">
-            <Button size="sm" variant="ghost" className="gap-1.5 text-xs h-7" onClick={() => setAdding(true)}>
+          <td colSpan={rowColSpan} className="px-4 py-2">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 gap-1.5 text-xs"
+              onClick={() => setAdding(true)}
+            >
               <Plus className="size-3.5" />
               Add row
             </Button>
-            {error && <span className="text-xs text-destructive ml-2">{error}</span>}
           </td>
         </tr>
       )}

--- a/components/dashboard/WeeklyScheduleCard.tsx
+++ b/components/dashboard/WeeklyScheduleCard.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CalendarDays, ChevronDown, Video } from "lucide-react";
+import { CalendarDays, ChevronDown, ChevronRight, Video } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { GoogleCalendarEmbed } from "@/components/events/GoogleCalendarEmbed";
-
-interface ScheduleRow {
-  id: string;
-  name: string;
-  days: string;
-  time: string;
-  zoom_url: string | null;
-  position: number;
-}
+import {
+  SCHEDULE_CATEGORIES,
+  getNextScheduleCategory,
+  getScheduleCategoryConfig,
+  type ScheduleCategory,
+  type ScheduleRow,
+} from "@/lib/utils/weekly-schedule";
 
 interface Props {
   rows: ScheduleRow[];
@@ -48,7 +46,50 @@ function useCalendarLayout() {
   return layout;
 }
 
-function ScheduleJoinLink({ url, className }: { url: string; className: string }) {
+function ScheduleCategoryTabs({
+  activeCategory,
+  onChange,
+}: {
+  activeCategory: ScheduleCategory;
+  onChange: (category: ScheduleCategory) => void;
+}) {
+  return (
+    <div
+      className="flex gap-1 px-3 pt-1 sm:gap-1.5 sm:px-4"
+      role="tablist"
+      aria-label="Schedule categories"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {SCHEDULE_CATEGORIES.map((cat) => {
+        const isActive = activeCategory === cat.value;
+        const { tabActive, tabInactive } = getScheduleCategoryConfig(cat.value);
+        return (
+          <button
+            key={cat.value}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(cat.value)}
+            className={cn(
+              "min-w-0 flex-1 rounded-lg px-2 py-2 text-center text-[11px] font-semibold leading-tight transition-colors sm:px-3 sm:py-2.5 sm:text-xs",
+              isActive ? tabActive : tabInactive
+            )}
+          >
+            {cat.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ScheduleJoinLink({
+  url,
+  className,
+}: {
+  url: string;
+  className: string;
+}) {
   return (
     <a
       href={url}
@@ -62,7 +103,21 @@ function ScheduleJoinLink({ url, className }: { url: string; className: string }
   );
 }
 
-function ScheduleRowCards({ rows }: { rows: ScheduleRow[] }) {
+function ScheduleRowCards({
+  rows,
+  joinButtonClass,
+}: {
+  rows: ScheduleRow[];
+  joinButtonClass: string;
+}) {
+  if (rows.length === 0) {
+    return (
+      <p className="px-4 py-8 text-center text-sm text-muted-foreground lg:hidden">
+        No meetings in this category yet.
+      </p>
+    );
+  }
+
   return (
     <ul className="divide-y lg:hidden">
       {rows.map((row) => (
@@ -77,7 +132,10 @@ function ScheduleRowCards({ rows }: { rows: ScheduleRow[] }) {
               {row.zoom_url ? (
                 <ScheduleJoinLink
                   url={row.zoom_url}
-                  className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-2.5 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:bg-blue-950/40 dark:text-blue-300 dark:hover:bg-blue-950/60"
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium",
+                    joinButtonClass
+                  )}
                 />
               ) : (
                 <span className="text-xs text-muted-foreground/40">—</span>
@@ -90,14 +148,58 @@ function ScheduleRowCards({ rows }: { rows: ScheduleRow[] }) {
   );
 }
 
+function ScheduleNextCategoryButton({
+  activeCategory,
+  onNext,
+}: {
+  activeCategory: ScheduleCategory;
+  onNext: () => void;
+}) {
+  const nextCategory = getNextScheduleCategory(activeCategory);
+  const nextConfig = getScheduleCategoryConfig(nextCategory);
+  const nextLabel = nextConfig.nextButtonLabel ?? nextConfig.label;
+
+  return (
+    <div
+      className="flex justify-center border-t px-3 py-2.5 sm:px-4"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <button
+        type="button"
+        onClick={onNext}
+        aria-label={`Show ${nextLabel}`}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors",
+          nextConfig.tabInactive
+        )}
+      >
+        {nextLabel}
+        <ChevronRight className="size-4 shrink-0" aria-hidden />
+      </button>
+    </div>
+  );
+}
+
 function ScheduleTable({
   rows,
+  allRows,
   isPlatformAdmin,
+  isAddingRow,
+  onAddingChange,
   AdminComponent,
+  activeCategory,
 }: {
   rows: ScheduleRow[];
+  allRows: ScheduleRow[];
   isPlatformAdmin: boolean;
-  AdminComponent: React.ComponentType<{ rows: ScheduleRow[] }> | null;
+  isAddingRow: boolean;
+  onAddingChange: (adding: boolean) => void;
+  AdminComponent: React.ComponentType<{
+    rows: ScheduleRow[];
+    activeCategory: ScheduleCategory;
+    onAddingChange?: (adding: boolean) => void;
+  }> | null;
+  activeCategory: ScheduleCategory;
 }) {
   return (
     <div className="overflow-x-auto overscroll-x-contain lg:overflow-visible">
@@ -105,7 +207,7 @@ function ScheduleTable({
         className={cn(
           "w-full text-sm",
           !isPlatformAdmin && "hidden lg:table",
-          isPlatformAdmin && "min-w-[32rem]"
+          isPlatformAdmin && "min-w-[40rem]"
         )}
       >
         <thead>
@@ -113,6 +215,11 @@ function ScheduleTable({
             <th className="px-3 py-2 text-left font-medium text-muted-foreground sm:px-4">
               Name
             </th>
+            {isPlatformAdmin && isAddingRow && (
+              <th className="px-3 py-2 text-left font-medium text-muted-foreground sm:px-4">
+                Category
+              </th>
+            )}
             <th className="px-3 py-2 text-left font-medium text-muted-foreground sm:px-4">
               Days
             </th>
@@ -126,7 +233,22 @@ function ScheduleTable({
           </tr>
         </thead>
         {isPlatformAdmin && AdminComponent ? (
-          <AdminComponent rows={rows} />
+          <AdminComponent
+            rows={allRows}
+            activeCategory={activeCategory}
+            onAddingChange={onAddingChange}
+          />
+        ) : rows.length === 0 ? (
+          <tbody>
+            <tr>
+              <td
+                colSpan={4}
+                className="px-4 py-8 text-center text-muted-foreground"
+              >
+                No meetings in this category yet.
+              </td>
+            </tr>
+          </tbody>
         ) : (
           <tbody>
             {rows.map((row, i) => (
@@ -135,13 +257,17 @@ function ScheduleTable({
                 className={i % 2 === 0 ? "border-b" : "border-b bg-muted/20"}
               >
                 <td className="px-3 py-2.5 font-medium sm:px-4">{row.name}</td>
-                <td className="px-3 py-2.5 text-muted-foreground sm:px-4">{row.days}</td>
-                <td className="px-3 py-2.5 text-muted-foreground sm:px-4">{row.time}</td>
+                <td className="px-3 py-2.5 text-muted-foreground sm:px-4">
+                  {row.days}
+                </td>
+                <td className="px-3 py-2.5 text-muted-foreground sm:px-4">
+                  {row.time}
+                </td>
                 <td className="px-3 py-2.5 sm:px-4">
                   {row.zoom_url ? (
                     <ScheduleJoinLink
                       url={row.zoom_url}
-                      className="inline-flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+                      className="inline-flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
                     />
                   ) : (
                     <span className="text-muted-foreground/40">—</span>
@@ -158,26 +284,61 @@ function ScheduleTable({
 
 export function WeeklyScheduleCard({ rows, isPlatformAdmin }: Props) {
   const [open, setOpen] = useState(true);
+  const [activeCategory, setActiveCategory] =
+    useState<ScheduleCategory>("general");
   const calendarLayout = useCalendarLayout();
-  const [AdminComponent, setAdminComponent] = useState<React.ComponentType<{ rows: ScheduleRow[] }> | null>(null);
+  const [AdminComponent, setAdminComponent] = useState<React.ComponentType<{
+    rows: ScheduleRow[];
+    activeCategory: ScheduleCategory;
+    onAddingChange?: (adding: boolean) => void;
+  }> | null>(null);
+  const [isAddingRow, setIsAddingRow] = useState(false);
+
+  const normalizedRows = useMemo(
+    () =>
+      rows.map((row) => ({
+        ...row,
+        category: (row.category ?? "general") as ScheduleCategory,
+      })),
+    [rows]
+  );
+
+  const filteredRows = useMemo(
+    () =>
+      normalizedRows
+        .filter((row) => row.category === activeCategory)
+        .sort((a, b) => a.position - b.position),
+    [normalizedRows, activeCategory]
+  );
+
+  const categoryConfig = getScheduleCategoryConfig(activeCategory);
+
+  function goToNextCategory() {
+    setActiveCategory(getNextScheduleCategory(activeCategory));
+    setIsAddingRow(false);
+  }
+
+  useEffect(() => {
+    if (isPlatformAdmin && !AdminComponent) {
+      import("./WeeklyScheduleAdmin").then((mod) => {
+        setAdminComponent(() => mod.WeeklyScheduleAdmin);
+      });
+    }
+  }, [isPlatformAdmin, AdminComponent]);
 
   async function handleOpen() {
-    if (!open && isPlatformAdmin && !AdminComponent) {
-      const mod = await import("./WeeklyScheduleAdmin");
-      setAdminComponent(() => mod.WeeklyScheduleAdmin);
-    }
     setOpen((o) => !o);
   }
 
   return (
-    <Card className="col-span-full overflow-hidden">
+    <Card className="col-span-full overflow-hidden border-l-4 border-l-accent-green">
       <CardHeader
         className="cursor-pointer select-none px-4 pb-3 sm:px-6"
         onClick={handleOpen}
       >
         <CardTitle className="flex items-center justify-between text-base font-semibold">
           <span className="flex items-center gap-2">
-            <CalendarDays className="size-4 shrink-0 text-muted-foreground" />
+            <CalendarDays className="size-4 shrink-0 text-accent-green" />
             Weekly Schedule
           </span>
           <ChevronDown
@@ -196,29 +357,50 @@ export function WeeklyScheduleCard({ rows, isPlatformAdmin }: Props) {
             href={CALENDAR_SUBSCRIBE_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="font-medium text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
+            className="font-medium text-accent-green underline underline-offset-2 hover:opacity-80"
           >
             click here
           </a>
           . If you want to add an event to our shared calendar, simply invite:{" "}
-          <span className="font-medium text-foreground">{SHARED_CALENDAR_EMAIL}</span>
+          <span className="font-medium text-foreground">
+            {SHARED_CALENDAR_EMAIL}
+          </span>
         </p>
       </CardHeader>
 
       {open && (
         <CardContent className="p-0">
-          <div className="grid gap-4 lg:grid-cols-2 lg:gap-0">
+          <ScheduleCategoryTabs
+            activeCategory={activeCategory}
+            onChange={setActiveCategory}
+          />
+          <div className="mt-3 grid gap-4 lg:grid-cols-2 lg:gap-0">
             <div className="min-w-0 border-b lg:border-b-0 lg:border-r">
-              {!isPlatformAdmin && <ScheduleRowCards rows={rows} />}
+              {!isPlatformAdmin && (
+                <ScheduleRowCards
+                  rows={filteredRows}
+                  joinButtonClass={categoryConfig.joinButton}
+                />
+              )}
               <ScheduleTable
-                rows={rows}
+                rows={filteredRows}
+                allRows={normalizedRows}
                 isPlatformAdmin={isPlatformAdmin}
+                isAddingRow={isAddingRow}
+                onAddingChange={setIsAddingRow}
                 AdminComponent={AdminComponent}
+                activeCategory={activeCategory}
+              />
+              <ScheduleNextCategoryButton
+                activeCategory={activeCategory}
+                onNext={goToNextCategory}
               />
             </div>
             <div className="min-w-0 px-3 pb-4 pt-1 sm:px-4 sm:pb-4 lg:p-4">
               <p className="mb-2 text-xs font-medium text-muted-foreground sm:mb-3">
-                {calendarLayout?.isMobile ? "Upcoming events" : "This week's events"}
+                {calendarLayout?.isMobile
+                  ? "Upcoming events"
+                  : "This week's events"}
               </p>
               {calendarLayout ? (
                 <GoogleCalendarEmbed

--- a/components/dashboard/WelcomeBanner.tsx
+++ b/components/dashboard/WelcomeBanner.tsx
@@ -3,8 +3,9 @@
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Briefcase, Users, UsersRound, MessageSquare } from "lucide-react";
+import { Users } from "lucide-react";
 import type { Profile } from "@/lib/types";
+import { featureFlags } from "@/lib/feature-flags";
 
 const MOTIVATIONAL_LINES = [
   "Together, we can take steps forward.",
@@ -45,30 +46,25 @@ export function WelcomeBanner({ profile }: WelcomeBannerProps) {
             <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
           </div>
           <div className="flex flex-wrap gap-2">
-              <Button variant="secondary" size="sm" asChild>
-                <Link href="/jobs">
-                  <Briefcase className="size-4" />
-                  Browse Jobs
-                </Link>
+            {featureFlags.ghostJobBoard && (
+              <Button
+                size="sm"
+                asChild
+                className="bg-primary-orange text-white hover:bg-primary-orange-hover"
+              >
+                <Link href="/jobs">Report a Ghost Job</Link>
               </Button>
-              <Button variant="secondary" size="sm" asChild>
-                <Link href="/members">
-                  <Users className="size-4" />
-                  Find Members
-                </Link>
-              </Button>
-              <Button variant="secondary" size="sm" asChild>
-                <Link href="/groups">
-                  <UsersRound className="size-4" />
-                  My Groups
-                </Link>
-              </Button>
-              <Button variant="secondary" size="sm" asChild>
-                <Link href="/messages">
-                  <MessageSquare className="size-4" />
-                  New Message
-                </Link>
-              </Button>
+            )}
+            <Button
+              size="sm"
+              asChild
+              className="bg-accent-green/10 text-accent-green hover:bg-accent-green/15 dark:bg-accent-green/15 dark:hover:bg-accent-green/25"
+            >
+              <Link href="/members">
+                <Users className="size-4" />
+                Connect with Members
+              </Link>
+            </Button>
           </div>
         </div>
       </CardContent>

--- a/components/shared/FeatureComingSoon.tsx
+++ b/components/shared/FeatureComingSoon.tsx
@@ -1,0 +1,9 @@
+export function FeatureComingSoon() {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <p className="text-lg text-muted-foreground">
+        Feature in testing. Coming soon!
+      </p>
+    </div>
+  );
+}

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,7 @@
+/** Toggle to re-enable gated features when ready for release. */
+export const featureFlags = {
+  jobApplicationTracker: false,
+  learningTracker: false,
+  myToolsNav: false,
+  ghostJobBoard: false,
+} as const;

--- a/lib/utils/weekly-schedule.ts
+++ b/lib/utils/weekly-schedule.ts
@@ -1,0 +1,59 @@
+export type ScheduleCategory =
+  | "general"
+  | "job_seekers"
+  | "organizers_volunteers";
+
+/** Maps to brand tiers in app/globals.css */
+type ScheduleBrandTone = "primary" | "green" | "tertiary";
+
+export interface ScheduleRow {
+  id: string;
+  name: string;
+  days: string;
+  time: string;
+  zoom_url: string | null;
+  position: number;
+  category: ScheduleCategory;
+}
+
+export const SCHEDULE_CATEGORIES: {
+  value: ScheduleCategory;
+  label: string;
+  nextButtonLabel?: string;
+  tone: ScheduleBrandTone;
+}[] = [
+  { value: "general", label: "General Meetings", tone: "green" },
+  {
+    value: "job_seekers",
+    label: "Job Seekers",
+    nextButtonLabel: "Job Seekers Events",
+    tone: "tertiary",
+  },
+  {
+    value: "organizers_volunteers",
+    label: "Organizers & Volunteers",
+    tone: "primary",
+  },
+];
+
+export function getScheduleCategoryConfig(category: ScheduleCategory) {
+  const config =
+    SCHEDULE_CATEGORIES.find((c) => c.value === category) ??
+    SCHEDULE_CATEGORIES[0];
+
+  const { tone } = config;
+  return {
+    ...config,
+    tabActive: `schedule-tab-active-${tone}`,
+    tabInactive: `schedule-tab-inactive-${tone}`,
+    joinButton: `schedule-join-${tone}`,
+  };
+}
+
+export function getNextScheduleCategory(
+  category: ScheduleCategory
+): ScheduleCategory {
+  const index = SCHEDULE_CATEGORIES.findIndex((c) => c.value === category);
+  const nextIndex = (index + 1) % SCHEDULE_CATEGORIES.length;
+  return SCHEDULE_CATEGORIES[nextIndex].value;
+}

--- a/lib/youtube/recent-videos.test.ts
+++ b/lib/youtube/recent-videos.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseYouTubePlaylistFeed } from "./recent-videos";
+
+const SAMPLE_FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">
+  <title>Test Playlist</title>
+  <entry>
+    <id>yt:video:abc12345678</id>
+    <yt:videoId>abc12345678</yt:videoId>
+    <title>First Workshop</title>
+    <published>2026-01-15T12:00:00+00:00</published>
+  </entry>
+  <entry>
+    <id>yt:video:def98765432</id>
+    <yt:videoId>def98765432</yt:videoId>
+    <title>Second &amp; Latest Workshop</title>
+    <published>2026-02-01T12:00:00+00:00</published>
+  </entry>
+</feed>`;
+
+describe("parseYouTubePlaylistFeed", () => {
+  it("parses video entries from playlist RSS", () => {
+    const videos = parseYouTubePlaylistFeed(SAMPLE_FEED, 5);
+
+    expect(videos).toHaveLength(2);
+    expect(videos[0]).toMatchObject({
+      id: "abc12345678",
+      title: "First Workshop",
+      url: "https://www.youtube.com/watch?v=abc12345678",
+      thumbnailUrl: "https://i.ytimg.com/vi/abc12345678/mqdefault.jpg",
+    });
+    expect(videos[1].title).toBe("Second & Latest Workshop");
+  });
+
+  it("respects the limit", () => {
+    expect(parseYouTubePlaylistFeed(SAMPLE_FEED, 1)).toHaveLength(1);
+  });
+});

--- a/lib/youtube/recent-videos.ts
+++ b/lib/youtube/recent-videos.ts
@@ -1,0 +1,65 @@
+/** Workshop playlist — same source as /social "Watch Our Past Workshops". */
+export const WORKSHOPS_PLAYLIST_ID = "PLNlQ1uwiLdQDPRV_DQXtNjc5fKNe95b8c";
+
+export const WORKSHOPS_PLAYLIST_URL = `https://www.youtube.com/playlist?list=${WORKSHOPS_PLAYLIST_ID}`;
+
+export interface YouTubeVideo {
+  id: string;
+  title: string;
+  publishedAt: string;
+  url: string;
+  thumbnailUrl: string;
+}
+
+function decodeXmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+export function parseYouTubePlaylistFeed(
+  xml: string,
+  limit = 5
+): YouTubeVideo[] {
+  const videos: YouTubeVideo[] = [];
+
+  for (const entry of xml.split("<entry>").slice(1)) {
+    if (videos.length >= limit) break;
+
+    const videoId =
+      entry.match(/<yt:videoId>([^<]+)<\/yt:videoId>/)?.[1] ??
+      entry.match(/<id>yt:video:([^<]+)<\/id>/)?.[1];
+    const title = entry.match(/<title>([^<]*)<\/title>/)?.[1];
+    const publishedAt = entry.match(/<published>([^<]+)<\/published>/)?.[1];
+
+    if (!videoId || !title) continue;
+
+    videos.push({
+      id: videoId,
+      title: decodeXmlEntities(title),
+      publishedAt: publishedAt ?? "",
+      url: `https://www.youtube.com/watch?v=${videoId}`,
+      thumbnailUrl: `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`,
+    });
+  }
+
+  return videos;
+}
+
+export async function fetchRecentVideos(
+  limit = 4
+): Promise<YouTubeVideo[]> {
+  try {
+    const res = await fetch(
+      `https://www.youtube.com/feeds/videos.xml?playlist_id=${WORKSHOPS_PLAYLIST_ID}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return [];
+    return parseYouTubePlaylistFeed(await res.text(), limit);
+  } catch {
+    return [];
+  }
+}

--- a/supabase/migrations/059_weekly_schedule_category.sql
+++ b/supabase/migrations/059_weekly_schedule_category.sql
@@ -1,0 +1,33 @@
+-- Category tabs for weekly schedule: General, Job Seekers, Organizers & Volunteers
+
+ALTER TABLE public.weekly_schedule
+  ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'general'
+  CHECK (category IN ('general', 'job_seekers', 'organizers_volunteers'));
+
+CREATE INDEX IF NOT EXISTS idx_weekly_schedule_category
+  ON public.weekly_schedule (category, position);
+
+-- Best-effort backfill for existing rows
+UPDATE public.weekly_schedule
+SET category = 'job_seekers'
+WHERE category = 'general'
+  AND (
+    name ILIKE '%job%app%'
+    OR name ILIKE '%job search%'
+    OR name ILIKE '%study group%'
+    OR name ILIKE '%mock interview%'
+  );
+
+UPDATE public.weekly_schedule
+SET category = 'organizers_volunteers'
+WHERE category = 'general'
+  AND (
+    name ILIKE '%working group%'
+    OR name ILIKE '%team meeting%'
+    OR name ILIKE '%internal meeting%'
+    OR name ILIKE '%policy%'
+    OR name ILIKE '%platform engineering%'
+    OR name ILIKE '%participatory%'
+    OR name ILIKE '%workforce development%'
+    OR name ILIKE '%media team%'
+  );


### PR DESCRIPTION
## Summary
- Tabbed Resource Hub navigation
- Gate WIP features behind feature flags and remove from side-nav bar
- Add categorized weekly schedule (tabs) with admin CRUD for adding new events, and migration 059
- Make onboarding LinkedIn optional
- Design update: dashboard cards and copy match brand colors

## Problem
The dashboard and navigation had grown cluttered with features that aren’t ready for members yet, while the areas we *do* want to highlight were hard to use or off-brand:
- **Weekly Schedule** showed all meetings in one list with no way to distinguish General Meetings, Job Seekers events, and Organizers & Volunteers sessions.
- **Dashboard** still surfaced LeetCode and generic “Announcements,” and didn’t reflect current branding or priorities (workshops, member connections, ghost jobs).
- **Resource Hub** was one long scroll, making it hard to find resources by type (organizations, communities, job boards, etc.).
- **Incomplete features** (Ghost Job Board, Job Application Tracker, Learning Tracker, My Tools) were visible in nav or on the dashboard, setting expectations we can’t meet yet.
- **Onboarding** required a LinkedIn URL even when applicants don’t have or want to share one.
- **Hosted Supabase** needs migration `059` for schedule categories; it was previously dropped on `main` to unblock deploys.

<img width="2188" height="1042" alt="Screenshot From 2026-07-02 15-40-45" src="https://github.com/user-attachments/assets/87a0fe59-269a-4759-ad4a-3e8bdab92191" />

NOTE: Too many events of too many categories.

## Solution
- **Weekly Schedule:** Category tabs with brand colors, next-category navigation, admin editing (category on add only), and migration `059` for the `category` column.
- **Dashboard refresh:** News & Updates (gold accent, scrollable), Recent Workshops (YouTube playlist), updated welcome banner, Community Poll rename, green accent on schedule card.
- **Resource Hub:** Section tabs in order: Organizations → Communities → Job Search → Labor Orgs → Learning → Tools → Articles → Other.
- **Feature gates:** `lib/feature-flags.ts` hides My Tools nav, Ghost Job Board (nav, button, and `/jobs` page), and shows coming-soon pages for both trackers.
- **Ghost Job Board:** Copy updated for future launch (`Report a Ghost`, etc.); fully gated until `ghostJobBoard` is enabled.
- **Onboarding:** LinkedIn URL optional; pending-approval and admin notification copy updated accordingly.
<img width="2206" height="1176" alt="Screenshot From 2026-07-02 17-40-18" src="https://github.com/user-attachments/assets/78aaae0d-4974-460f-9b57-d35f61a4a687" />


NOTE: Tabbed meetings and resource sections make it easier for people to find a limited list of events that interest them.
<img width="2206" height="1176" alt="Screenshot From 2026-07-02 17-41-49" src="https://github.com/user-attachments/assets/d70f0b4d-a29d-4d7e-a957-07152c3a3d39" />

## Deploy notes

- **Required:** Apply `supabase/migrations/059_weekly_schedule_category.sql` on hosted Supabase before deploy, then run `NOTIFY pgrst, 'reload schema';`
- Note: `main` previously dropped migration 059; this PR reintroduces it for weekly schedule categories.

## Test plan

- [ ] Apply migration 059 on staging/prod Supabase and verify weekly schedule loads and admin can add/edit/delete rows per category
- [ ] Dashboard: confirm News & Updates scrolls, Recent Workshops shows videos (or fallback link), schedule tabs and next-category buttons work
- [ ] Resource Hub: verify tab order and section content; Job Search sub-sections (Remote, Civic, General) still render
- [ ] Confirm My Tools and Ghost Job Board are hidden from nav/dashboard; `/jobs`, `/tracker`, and `/learning/tracker` show “Feature in testing. Coming soon!”
- [ ] Complete onboarding without LinkedIn; confirm submission succeeds and admin approval email shows “Not provided”
- [ ] Run `npm test` and `npm run lint` (249 tests passing locally)